### PR TITLE
Update/add dns entry on instance init

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.80"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.86"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.80"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.86"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.80"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.86"
 
   application                      = var.application
   application_type                 = "chips"


### PR DESCRIPTION
Bump version of chips-app terraform module to pull in latest module with the dns update functionality.

Resolves https://companieshouse.atlassian.net/browse/CM-893