### PR TITLE
Add additional ingress rules for tuxedo

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.88"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.91"
 
   application                      = var.application
   application_type                 = "chips"
@@ -44,6 +44,16 @@ module "chips-ef-batch" {
   nfs_mounts                       = var.nfs_mounts
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
+
+  additional_ingress_with_cidr_blocks = [
+    {
+      from_port   = 49075
+      to_port     = 49078
+      protocol    = "tcp"
+      description = "Tuxedo ports"
+      cidr_blocks = join(",", [for s in module.chips-ef-batch.application_subnets : s.cidr_block])
+    }
+  ]
 
   additional_userdata_suffix = <<-EOT
   su -l ec2-user bootstrap

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.88"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.91"
 
   application                      = var.application
   application_type                 = "chips"
@@ -44,6 +44,16 @@ module "chips-tux-proxy" {
   nfs_mounts                       = var.nfs_mounts
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
+
+  additional_ingress_with_cidr_blocks = [
+    {
+      from_port   = 21075
+      to_port     = 21076
+      protocol    = "tcp"
+      description = "Tuxedo proxy ports"
+      cidr_blocks = join(",", [for s in module.chips-tux-proxy.application_subnets : s.cidr_block])
+    }
+  ]
 
   additional_userdata_suffix = <<-EOT
   su -l ec2-user bootstrap

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.88"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.91"
 
   application                      = var.application
   application_type                 = "chips"
@@ -44,6 +44,16 @@ module "chips-users-rest" {
   nfs_mounts                       = var.nfs_mounts
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
+
+  additional_ingress_with_cidr_blocks = [
+    {
+      from_port   = 49075
+      to_port     = 49078
+      protocol    = "tcp"
+      description = "Tuxedo ports"
+      cidr_blocks = join(",", [for s in module.chips-users-rest.application_subnets : s.cidr_block])
+    }
+  ]
 
   additional_userdata_suffix = <<-EOT
   su -l ec2-user bootstrap


### PR DESCRIPTION
Specify additional ingress rules to allow access to tuxedo ports from the application subnet - this allows the chips-tux-proxy to talk to the chips-ef-batch & chips-rest-users clusters and also the NLB to talk to the chips-tux-proxy.

Resolves https://companieshouse.atlassian.net/browse/CM-895