### PR TITLE
Advance version of chips-app terraform module to 1.0.94

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.93"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.94"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.93"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.94"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.93"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.94"
 
   application                      = var.application
   application_type                 = "chips"


### PR DESCRIPTION
This pulls in the change to allow ingress from CHS cidrs for http/https REST calls

Resolves: https://companieshouse.atlassian.net/browse/CM-943