### PR TITLE
Add application log groups and live config

### DIFF
--- a/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
@@ -61,4 +61,154 @@ cloudwatch_logs = {
     file_name = "amazon-ssm-agent.log"
     log_group_retention = 7
   }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 7
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 7
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
+
+  "sso1-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso1-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso2-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso2-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso3-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso3-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso4-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso4-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "eaidaemon-log" = {
+    file_path = "NFSPATH/running-servers/eaidaemon"
+    file_name = "eai-eaidaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "batchmanager-log" = {
+    file_path = "NFSPATH/running-servers/batchmanager"
+    file_name = "batch-batchmanager-*.log"
+    log_group_retention = 7
+  }
 }

--- a/groups/chips-ef-batch/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-live-eu-west-2/vars
@@ -1,0 +1,214 @@
+# Account details
+aws_profile = "heritage-live-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-live"
+
+# Account shorthand
+account = "hlive"
+region  = "euw2"
+
+# Application details
+application = "chips-ef-batch"
+environment = "live"
+
+# ASG settings
+asg_count = 2
+instance_size = "z1d.xlarge"
+
+# CVO NFS Mounts
+nfs_server = "192.168.255.35"
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+nfs_mounts = {
+  application_root = {
+    local_mount_point = "chips"
+    nfs_source_mount  = "chips"
+  }
+}
+
+############################################
+# Log entries to be aggregated in Cloudwatch Logs
+# 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )
+############################################
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 180
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 180
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 180
+  }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 180
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 180
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 180
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 180
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 180
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 180
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 180
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 180
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 180
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 180
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 180
+  }
+
+  "sso1-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso1-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "sso2-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso2-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "sso3-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso3-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "sso4-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso4-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "eaidaemon-log" = {
+    file_path = "NFSPATH/running-servers/eaidaemon"
+    file_name = "eai-eaidaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "batchmanager-log" = {
+    file_path = "NFSPATH/running-servers/batchmanager"
+    file_name = "batch-batchmanager-*.log"
+    log_group_retention = 180
+  }
+}

--- a/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
@@ -61,4 +61,154 @@ cloudwatch_logs = {
     file_name = "amazon-ssm-agent.log"
     log_group_retention = 7
   }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 7
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 7
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
+
+  "sso1-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso1-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso2-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso2-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso3-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso3-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso4-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso4-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "eaidaemon-log" = {
+    file_path = "NFSPATH/running-servers/eaidaemon"
+    file_name = "eai-eaidaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "batchmanager-log" = {
+    file_path = "NFSPATH/running-servers/batchmanager"
+    file_name = "batch-batchmanager-*.log"
+    log_group_retention = 7
+  }
 }

--- a/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
@@ -61,4 +61,64 @@ cloudwatch_logs = {
     file_name = "amazon-ssm-agent.log"
     log_group_retention = 7
   }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
 }

--- a/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
@@ -1,0 +1,106 @@
+# Account details
+aws_profile = "heritage-live-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-live"
+
+# Account shorthand
+account = "hlive"
+region  = "euw2"
+
+# Application details
+application = "chips-tux-proxy"
+environment = "live"
+
+# ASG settings
+asg_count = 2
+instance_size = "t3.medium"
+
+# CVO NFS Mounts
+nfs_server = "192.168.255.35"
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+nfs_mounts = {
+  application_root = {
+    local_mount_point = "chips"
+    nfs_source_mount  = "chips"
+  }
+}
+
+############################################
+# Log entries to be aggregated in Cloudwatch Logs
+# 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )
+############################################
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 180
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 180
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 180
+  }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 180
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 180
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 180
+  }
+}

--- a/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
@@ -61,4 +61,64 @@ cloudwatch_logs = {
     file_name = "amazon-ssm-agent.log"
     log_group_retention = 7
   }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
 }

--- a/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
@@ -61,4 +61,148 @@ cloudwatch_logs = {
     file_name = "amazon-ssm-agent.log"
     log_group_retention = 7
   }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 7
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 7
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
+
+  "sso1-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso1-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso2-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso2-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso3-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso3-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso4-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso4-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "eaidaemon-log" = {
+    file_path = "NFSPATH/running-servers/eaidaemon"
+    file_name = "eai-eaidaemon-*.log"
+    log_group_retention = 7
+  }
 }

--- a/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
@@ -1,0 +1,208 @@
+# Account details
+aws_profile = "heritage-live-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-live"
+
+# Account shorthand
+account = "hlive"
+region  = "euw2"
+
+# Application details
+application = "chips-users-rest"
+environment = "live"
+
+# ASG settings
+asg_count = 2
+instance_size = "z1d.xlarge"
+
+# CVO NFS Mounts
+nfs_server = "192.168.255.35"
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+nfs_mounts = {
+  application_root = {
+    local_mount_point = "chips"
+    nfs_source_mount  = "chips"
+  }
+}
+
+############################################
+# Log entries to be aggregated in Cloudwatch Logs
+# 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )
+############################################
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 180
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 180
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 180
+  }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 180
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 180
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 180
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 180
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 180
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 180
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 180
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 180
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 180
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 180
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 180
+  }
+
+  "sso1-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso1-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "sso2-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso2-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "sso3-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso3-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "sso4-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso4-ssodaemon-*.log"
+    log_group_retention = 180
+  }
+
+  "eaidaemon-log" = {
+    file_path = "NFSPATH/running-servers/eaidaemon"
+    file_name = "eai-eaidaemon-*.log"
+    log_group_retention = 180
+  }
+}

--- a/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
@@ -61,4 +61,148 @@ cloudwatch_logs = {
     file_name = "amazon-ssm-agent.log"
     log_group_retention = 7
   }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 7
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 7
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
+
+  "sso1-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso1-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso2-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso2-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso3-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso3-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "sso4-log" = {
+    file_path = "NFSPATH/running-servers/ssodaemon"
+    file_name = "sso4-ssodaemon-*.log"
+    log_group_retention = 7
+  }
+
+  "eaidaemon-log" = {
+    file_path = "NFSPATH/running-servers/eaidaemon"
+    file_name = "eai-eaidaemon-*.log"
+    log_group_retention = 7
+  }
 }


### PR DESCRIPTION
Adds the log group/file definitions for the application logs (WebLogic/Apache/EAI/SSO), and also adds the live vars needed for the infrastructure deployment to heritage-live.

Resolves: https://companieshouse.atlassian.net/browse/CM-992