### PR TITLE
Reference version 1.0.96 of chips-app module

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.95"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.96"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.94"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.95"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.95"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.96"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.94"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.95"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.94"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.95"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.95"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.96"
 
   application                      = var.application
   application_type                 = "chips"


### PR DESCRIPTION
This pulls in the change done to reduce the size of the IAM policy by only writing one resource entry for each log group.

Resolves: https://companieshouse.atlassian.net/browse/CM-992