### PR TITLE
Update development vars for deployment

### DIFF
--- a/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
@@ -21,7 +21,7 @@ performance_insights_enabled = false
 
 # RDS Engine settings
 major_engine_version       = "19"
-engine_version             = "19.0"
+engine_version             = "19"
 license_model              = "license-included"
 auto_minor_version_upgrade = true
 
@@ -38,10 +38,6 @@ parameter_group_settings = [
     {
       name  = "aq_tm_processes"
       value = "6"
-    },
-    {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
     },
     {
       name         = "compatible"


### PR DESCRIPTION
Removed sec_case_sensitive_logon from parameter group params as it's no longer configurable in Oracle 19
Corrected `engine_version` value