### PR TITLE
Update RDS Parameters for Toad Access on Oracle 19

### DIFF
--- a/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
@@ -96,10 +96,6 @@ parameter_group_settings = [
       value = "10"
     },
     {
-      name  = "undo_retention"
-      value = "900"
-    },
-    {
       name         = "timed_statistics"
       value        = "TRUE"
       apply_method = "pending-reboot"

--- a/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
@@ -88,6 +88,18 @@ parameter_group_settings = [
       apply_method = "pending-reboot"
     },
     {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
+    },
+    {
+      name  = "undo_retention"
+      value = "900"
+    },
+    {
       name         = "timed_statistics"
       value        = "TRUE"
       apply_method = "pending-reboot"


### PR DESCRIPTION
Updated parameter_group parameters to allow Toad access on Oracle 19 RDS
* sqlnetora.sqlnet.allowed_logon_version_client -> "10"
* sqlnetora.sqlnet.allowed_logon_version_server -> "10"

Resolves: CM-1092