### PR TITLE
Disable the creation of the tuxedo NLB

### DIFF
--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -44,7 +44,6 @@ module "chips-tux-proxy" {
   nfs_mounts                       = var.nfs_mounts
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
-  create_tuxedo_nlb                = true
 
   additional_ingress_with_cidr_blocks = [
     {


### PR DESCRIPTION
Stop creating an NLB for the chips-tux-proxy group.  I've left the capability/functionality in the chips-app module, in case it is needed in future, and just removed the setting of the `create_tuxedo_nlb` var, so it uses its default value of false.

Resolves: https://companieshouse.atlassian.net/browse/CM-1119