### PR TITLE
Disable instance refresh in staging and live environments

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.96"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.100"
 
   application                      = var.application
   application_type                 = "chips"
@@ -39,6 +39,7 @@ module "chips-ef-batch" {
   environment                      = var.environment
   asg_count                        = var.asg_count
   instance_size                    = var.instance_size
+  enable_instance_refresh          = var.enable_instance_refresh
   nfs_server                       = var.nfs_server
   nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
   nfs_mounts                       = var.nfs_mounts

--- a/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
@@ -14,6 +14,7 @@ environment = "development"
 # ASG settings
 asg_count = 1
 instance_size = "z1d.large"
+enable_instance_refresh = true
 
 # CVO NFS Mounts
 nfs_server = "10.104.9.145"

--- a/groups/chips-ef-batch/variables.tf
+++ b/groups/chips-ef-batch/variables.tf
@@ -58,7 +58,7 @@ variable "environment" {
 }
 
 # ------------------------------------------------------------------------------
-# CIC ASG Variables
+# CHIPS ASG Variables
 # ------------------------------------------------------------------------------
 
 variable "instance_size" {
@@ -107,9 +107,14 @@ variable "alb_deletion_protection" {
   description = "Enable or disable deletion protection for instances"
 }
 
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
 
 # ------------------------------------------------------------------------------
-# CIC ALB Variables
+# CHIPS ALB Variables
 # ------------------------------------------------------------------------------
 
 variable "application_port" {

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.96"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.100"
 
   application                      = var.application
   application_type                 = "chips"
@@ -39,6 +39,7 @@ module "chips-tux-proxy" {
   environment                      = var.environment
   asg_count                        = var.asg_count
   instance_size                    = var.instance_size
+  enable_instance_refresh          = var.enable_instance_refresh
   nfs_server                       = var.nfs_server
   nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
   nfs_mounts                       = var.nfs_mounts

--- a/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
@@ -14,6 +14,7 @@ environment = "development"
 # ASG settings
 asg_count = 1
 instance_size = "t3.medium"
+enable_instance_refresh = true
 
 # CVO NFS Mounts
 nfs_server = "10.104.9.145"

--- a/groups/chips-tux-proxy/variables.tf
+++ b/groups/chips-tux-proxy/variables.tf
@@ -58,7 +58,7 @@ variable "environment" {
 }
 
 # ------------------------------------------------------------------------------
-# CIC ASG Variables
+# CHIPS ASG Variables
 # ------------------------------------------------------------------------------
 
 variable "instance_size" {
@@ -107,9 +107,14 @@ variable "alb_deletion_protection" {
   description = "Enable or disable deletion protection for instances"
 }
 
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
 
 # ------------------------------------------------------------------------------
-# CIC ALB Variables
+# CHIPS ALB Variables
 # ------------------------------------------------------------------------------
 
 variable "application_port" {

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.96"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.100"
 
   application                      = var.application
   application_type                 = "chips"
@@ -39,6 +39,7 @@ module "chips-users-rest" {
   environment                      = var.environment
   asg_count                        = var.asg_count
   instance_size                    = var.instance_size
+  enable_instance_refresh          = var.enable_instance_refresh
   nfs_server                       = var.nfs_server
   nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
   nfs_mounts                       = var.nfs_mounts

--- a/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
@@ -14,6 +14,7 @@ environment = "development"
 # ASG settings
 asg_count = 1
 instance_size = "z1d.large"
+enable_instance_refresh = true
 
 # CVO NFS Mounts
 nfs_server = "10.104.9.145"

--- a/groups/chips-users-rest/variables.tf
+++ b/groups/chips-users-rest/variables.tf
@@ -58,7 +58,7 @@ variable "environment" {
 }
 
 # ------------------------------------------------------------------------------
-# CIC ASG Variables
+# CHIPS ASG Variables
 # ------------------------------------------------------------------------------
 
 variable "instance_size" {
@@ -107,9 +107,14 @@ variable "alb_deletion_protection" {
   description = "Enable or disable deletion protection for instances"
 }
 
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
 
 # ------------------------------------------------------------------------------
-# CIC ALB Variables
+# CHIPS ALB Variables
 # ------------------------------------------------------------------------------
 
 variable "application_port" {


### PR DESCRIPTION
Adds a var `enable_instance_refresh` that has a default of false.  This is overridden by setting to true in the heritage-development environment.

This var value is then passed into the chips-app ASG module, so we can stop instances being refreshed automatically. We need to disable instance refresh in live to avoid impacting users/traffic with a rolling refresh.

Resolves: https://companieshouse.atlassian.net/browse/CM-1127 