### PR TITLE
Add batt14 and image mounts for staging

### DIFF
--- a/groups/chips-ef-batch/data.tf
+++ b/groups/chips-ef-batch/data.tf
@@ -1,0 +1,3 @@
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
+}

--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -31,7 +31,7 @@ module "chips-ef-batch" {
   source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.101"
 
   application                      = var.application
-  application_type                 = "chips"
+  application_type                 = var.application_type
   aws_region                       = var.aws_region
   aws_account                      = var.aws_account
   account                          = var.account
@@ -40,9 +40,8 @@ module "chips-ef-batch" {
   asg_count                        = var.asg_count
   instance_size                    = var.instance_size
   enable_instance_refresh          = var.enable_instance_refresh
-  nfs_server                       = var.nfs_server
   nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = var.nfs_mounts
+  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
 

--- a/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
@@ -16,15 +16,8 @@ asg_count = 1
 instance_size = "z1d.large"
 enable_instance_refresh = true
 
-# CVO NFS Mounts
-nfs_server = "10.104.9.145"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-ef-batch/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-live-eu-west-2/vars
@@ -15,15 +15,8 @@ environment = "live"
 asg_count = 2
 instance_size = "z1d.xlarge"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.35"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
@@ -15,13 +15,25 @@ environment = "staging"
 asg_count = 2
 instance_size = "z1d.large"
 
-# CVO NFS Mounts
+# NFS Mounts - default NFS server is CVO
 nfs_server = "192.168.255.19"
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 nfs_mounts = {
   application_root = {
     local_mount_point = "chips"
     nfs_source_mount  = "chips"
+  }
+
+  batt14 = {
+    local_mount_point  = "batt14"
+    nfs_source_mount   = "/vol/data0/Home/batt14"
+    nfs_server_address = "chfas-pl1.internal.ch"
+  }
+
+  image = {
+    local_mount_point  = "image"
+    nfs_source_mount   = "/vol/data0/test_image"
+    nfs_server_address = "chfas-pl1.internal.ch"
   }
 }
 

--- a/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
@@ -15,27 +15,8 @@ environment = "staging"
 asg_count = 2
 instance_size = "z1d.large"
 
-# NFS Mounts - default NFS server is CVO
-nfs_server = "192.168.255.19"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-
-  batt14 = {
-    local_mount_point  = "batt14"
-    nfs_source_mount   = "/vol/data0/Home/batt14"
-    nfs_server_address = "chfas-pl1.internal.ch"
-  }
-
-  image = {
-    local_mount_point  = "image"
-    nfs_source_mount   = "/vol/data0/test_image"
-    nfs_server_address = "chfas-pl1.internal.ch"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-ef-batch/variables.tf
+++ b/groups/chips-ef-batch/variables.tf
@@ -49,12 +49,18 @@ variable "region" {
 
 variable "application" {
   type        = string
-  description = "The name of the application"
+  description = "The component name of the application"
 }
 
 variable "environment" {
   type        = string
   description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
 }
 
 # ------------------------------------------------------------------------------
@@ -152,31 +158,10 @@ variable "domain_name" {
 # ------------------------------------------------------------------------------
 # See Ansible role for full documentation on NFS arguements:
 #      https://github.com/companieshouse/ansible-collections/tree/main/ch_collections/heritage_services/roles/nfs/files/nfs_mounts
-variable "nfs_server" {
-  type        = string
-  description = "The name or IP of the environment specific NFS server"
-  default     = null
-}
-
 variable "nfs_mount_destination_parent_dir" {
   type        = string
   description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
   default     = "/mnt"
-}
-
-variable "nfs_mounts" {
-  type        = map(any)
-  description = "A map of objects which contains mount details for each mount path required."
-  # Example: 
-  #   nfs_share_name = {                  # The name of the NFS Share from the NFS Server
-  #     local_mount_point = "folder",     # The name of the local folder to mount to under the parent directory, if omitted the share name is used.
-  #     mount_options = [                 # Traditional mount options as documented for any NFS Share mounts
-  #       "rw",
-  #       "wsize=8192"
-  #     ]
-  #   }
-  # }
-  #
 }
 
 variable "default_log_group_retention_in_days" {

--- a/groups/chips-tux-proxy/data.tf
+++ b/groups/chips-tux-proxy/data.tf
@@ -1,0 +1,3 @@
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
+}

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -40,9 +40,8 @@ module "chips-tux-proxy" {
   asg_count                        = var.asg_count
   instance_size                    = var.instance_size
   enable_instance_refresh          = var.enable_instance_refresh
-  nfs_server                       = var.nfs_server
   nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = var.nfs_mounts
+  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
 

--- a/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
@@ -16,15 +16,8 @@ asg_count = 1
 instance_size = "t3.medium"
 enable_instance_refresh = true
 
-# CVO NFS Mounts
-nfs_server = "10.104.9.145"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
@@ -15,15 +15,8 @@ environment = "live"
 asg_count = 2
 instance_size = "t3.medium"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.35"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
@@ -15,15 +15,8 @@ environment = "staging"
 asg_count = 2
 instance_size = "t3.medium"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.19"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-tux-proxy/variables.tf
+++ b/groups/chips-tux-proxy/variables.tf
@@ -49,12 +49,18 @@ variable "region" {
 
 variable "application" {
   type        = string
-  description = "The name of the application"
+  description = "The component name of the application"
 }
 
 variable "environment" {
   type        = string
   description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
 }
 
 # ------------------------------------------------------------------------------
@@ -152,31 +158,10 @@ variable "domain_name" {
 # ------------------------------------------------------------------------------
 # See Ansible role for full documentation on NFS arguements:
 #      https://github.com/companieshouse/ansible-collections/tree/main/ch_collections/heritage_services/roles/nfs/files/nfs_mounts
-variable "nfs_server" {
-  type        = string
-  description = "The name or IP of the environment specific NFS server"
-  default     = null
-}
-
 variable "nfs_mount_destination_parent_dir" {
   type        = string
   description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
   default     = "/mnt"
-}
-
-variable "nfs_mounts" {
-  type        = map(any)
-  description = "A map of objects which contains mount details for each mount path required."
-  # Example: 
-  #   nfs_share_name = {                  # The name of the NFS Share from the NFS Server
-  #     local_mount_point = "folder",     # The name of the local folder to mount to under the parent directory, if omitted the share name is used.
-  #     mount_options = [                 # Traditional mount options as documented for any NFS Share mounts
-  #       "rw",
-  #       "wsize=8192"
-  #     ]
-  #   }
-  # }
-  #
 }
 
 variable "default_log_group_retention_in_days" {

--- a/groups/chips-users-rest/data.tf
+++ b/groups/chips-users-rest/data.tf
@@ -1,0 +1,3 @@
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
+}

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -40,9 +40,8 @@ module "chips-users-rest" {
   asg_count                        = var.asg_count
   instance_size                    = var.instance_size
   enable_instance_refresh          = var.enable_instance_refresh
-  nfs_server                       = var.nfs_server
   nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = var.nfs_mounts
+  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
   cloudwatch_logs                  = var.cloudwatch_logs
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
 

--- a/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
@@ -16,15 +16,8 @@ asg_count = 1
 instance_size = "z1d.large"
 enable_instance_refresh = true
 
-# CVO NFS Mounts
-nfs_server = "10.104.9.145"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
@@ -15,15 +15,8 @@ environment = "live"
 asg_count = 2
 instance_size = "z1d.xlarge"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.35"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
@@ -16,7 +16,7 @@ asg_count = 2
 instance_size = "z1d.large"
 
 # NFS Mounts - default NFS server is CVO
-nfs_server = "192.168.255.19" 
+nfs_server = "192.168.255.19"
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 nfs_mounts = {
   application_root = {

--- a/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
@@ -15,27 +15,8 @@ environment = "staging"
 asg_count = 2
 instance_size = "z1d.large"
 
-# NFS Mounts - default NFS server is CVO
-nfs_server = "192.168.255.19"
+# NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
-nfs_mounts = {
-  application_root = {
-    local_mount_point = "chips"
-    nfs_source_mount  = "chips"
-  }
-
-  batt14 = {
-    local_mount_point  = "batt14"
-    nfs_source_mount   = "/vol/data0/Home/batt14"
-    nfs_server_address = "chfas-pl1.internal.ch"
-  }
-
-  image = {
-    local_mount_point  = "image"
-    nfs_source_mount   = "/vol/data0/test_image"
-    nfs_server_address = "chfas-pl1.internal.ch"
-  }   
-}
 
 ############################################
 # Log entries to be aggregated in Cloudwatch Logs

--- a/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
@@ -15,14 +15,26 @@ environment = "staging"
 asg_count = 2
 instance_size = "z1d.large"
 
-# CVO NFS Mounts
-nfs_server = "192.168.255.19"
+# NFS Mounts - default NFS server is CVO
+nfs_server = "192.168.255.19" 
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 nfs_mounts = {
   application_root = {
     local_mount_point = "chips"
     nfs_source_mount  = "chips"
   }
+
+  batt14 = {
+    local_mount_point  = "batt14"
+    nfs_source_mount   = "/vol/data0/Home/batt14"
+    nfs_server_address = "chfas-pl1.internal.ch"
+  }
+
+  image = {
+    local_mount_point  = "image"
+    nfs_source_mount   = "/vol/data0/test_image"
+    nfs_server_address = "chfas-pl1.internal.ch"
+  }   
 }
 
 ############################################

--- a/groups/chips-users-rest/variables.tf
+++ b/groups/chips-users-rest/variables.tf
@@ -49,12 +49,18 @@ variable "region" {
 
 variable "application" {
   type        = string
-  description = "The name of the application"
+  description = "The component name of the application"
 }
 
 variable "environment" {
   type        = string
   description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
 }
 
 # ------------------------------------------------------------------------------
@@ -152,31 +158,10 @@ variable "domain_name" {
 # ------------------------------------------------------------------------------
 # See Ansible role for full documentation on NFS arguements:
 #      https://github.com/companieshouse/ansible-collections/tree/main/ch_collections/heritage_services/roles/nfs/files/nfs_mounts
-variable "nfs_server" {
-  type        = string
-  description = "The name or IP of the environment specific NFS server"
-  default     = null
-}
-
 variable "nfs_mount_destination_parent_dir" {
   type        = string
   description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
   default     = "/mnt"
-}
-
-variable "nfs_mounts" {
-  type        = map(any)
-  description = "A map of objects which contains mount details for each mount path required."
-  # Example: 
-  #   nfs_share_name = {                  # The name of the NFS Share from the NFS Server
-  #     local_mount_point = "folder",     # The name of the local folder to mount to under the parent directory, if omitted the share name is used.
-  #     mount_options = [                 # Traditional mount options as documented for any NFS Share mounts
-  #       "rw",
-  #       "wsize=8192"
-  #     ]
-  #   }
-  # }
-  #
 }
 
 variable "default_log_group_retention_in_days" {


### PR DESCRIPTION
Add CHIPS mounts for staging to support writing to dbclobs, fes_dbclobs and reading from the test_image share.

The NFS config was previously hardcoded and this has now been moved into vault under the path
`/applications/<account>-eu-west-2/chips/app/nfs_mounts`
(where <account> is heritage-development, heritage-staging or heritage-live

There is a key present under that path for each of the current application types, chips-user-rest-mounts, chips-ef-batch-mounts & chips-tux-proxy-mounts and the value of that key is a map of NFS mounts as expected by the ansible code here: https://github.com/companieshouse/ansible-collections/blob/main/ch_collections/heritage_services/roles/nfs/files/nfs_mounts/templates/mounts.j2

The map is of the form:
```
{
	"application_root": {
		"local_mount_point": "chips",
		"nfs_source_mount": "chips",
		"nfs_server_address": "1.2.3.4"
	},
	"mountname1": {
		"local_mount_point": "mountasname1",
		"nfs_source_mount": "/path/to/export",
		"nfs_server_address": "mynfsserver.internal.ch"
	},
	"mountname2": {
		"local_mount_point": "mountasname2",
		"nfs_source_mount": "/path/to/export",
		"nfs_server_address": "mynfsserver.internal.ch"
	}
}
```

Resolves: https://companieshouse.atlassian.net/browse/CM-1154