### PR TITLE
Adding new rule for iprocess app access to DB instance

### DIFF
--- a/groups/staffware-db/data.tf
+++ b/groups/staffware-db/data.tf
@@ -14,6 +14,14 @@ data "aws_security_group" "nagios_shared" {
   }
 }
 
+
+data "aws_security_group" "iprocess_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-iprocess-app-asg-*"]
+  }
+}
+
 data "aws_subnet_ids" "data" {
   vpc_id = data.aws_vpc.vpc.id
   filter {

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -15,7 +15,15 @@ module "db_ec2_security_group" {
       rule = "all-all"
     }
   ]
-
+  ingress_with_source_security_group_id = [
+    {
+      from_port                = 1521
+      to_port                  = 1521
+      protocol                 = "tcp"
+      description              = "iProcess Application Security Group"
+      source_security_group_id = data.aws_security_group.iprocess_app.id
+    }
+  ]
   ingress_with_cidr_blocks = [
     {
       from_port   = 1521
@@ -48,7 +56,7 @@ module "db_ec2_security_group" {
 resource "aws_instance" "db_ec2" {
   count = var.db_instance_count
 
-  ami = data.aws_ami.oracle_12.id
+  ami = var.ami_id == null ? data.aws_ami.oracle_12.id : var.ami_id
 
   key_name      = aws_key_pair.ec2_keypair.key_name
   instance_type = var.db_instance_size

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -12,6 +12,7 @@ environment = "staging"
 
 db_instance_count = 2
 db_instance_size = "r5.4xlarge"
+ami_id = "ami-07753d6b2935e32bf"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -74,6 +74,11 @@ variable "ami_name" {
   description = "Name of the AMI to use in the Auto Scaling configuration for email servers"
 }
 
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = "Id of an AMI you want to force the Terraform to use, overrides ami_name"
+}
 
 variable "vpc_sg_cidr_blocks_oracle" {
   type        = list(any)


### PR DESCRIPTION
Adding new rule for iprocess app access to DB instance, adding option to hardcode AMI Id to stop instance rebuilds when new AMIs are avaiable