### PR TITLE
Call weblogic-pre-bootstrap.sh on startup prior to bootstrap

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -56,6 +56,7 @@ module "chips-ef-batch" {
   ]
 
   additional_userdata_suffix = <<-EOT
+  su -l ec2-user weblogic-pre-bootstrap.sh
   su -l ec2-user bootstrap
   EOT
 

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -56,6 +56,7 @@ module "chips-tux-proxy" {
   ]
 
   additional_userdata_suffix = <<-EOT
+  su -l ec2-user weblogic-pre-bootstrap.sh
   su -l ec2-user bootstrap
   EOT
 }

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -56,6 +56,7 @@ module "chips-users-rest" {
   ]
 
   additional_userdata_suffix = <<-EOT
+  su -l ec2-user weblogic-pre-bootstrap.sh
   su -l ec2-user bootstrap
   EOT
 }


### PR DESCRIPTION
This adds a call to the WebLogic Pre Bootstrap script which "unlocks" any locked files on the NFS that can sometimes be encountered after a hard restart.

Resolves: https://companieshouse.atlassian.net/browse/CM-1190