### PR TITLE
Allow access from CHIPS app to iProcess application and database

### DIFF
--- a/groups/staffware-app/asg_frontend.tf
+++ b/groups/staffware-app/asg_frontend.tf
@@ -45,8 +45,15 @@ module "iprocess_app_asg_security_group" {
       from_port                = 30511
       to_port                  = 30514
       protocol                 = "tcp"
-      description              = "WebLogic inbound port range"
-      source_security_group_id = data.aws_security_group.chips_weblogic.id
+      description              = "WebLogic chips-users-rest inbound port range"
+      source_security_group_id = data.aws_security_group.chips_users_rest_app.id
+    },
+    {
+      from_port                = 30511
+      to_port                  = 30514
+      protocol                 = "tcp"
+      description              = "WebLogic chips-ef-batch inbound port range"
+      source_security_group_id = data.aws_security_group.chips_ef_batch_app.id
     }
   ]
   number_of_computed_ingress_with_source_security_group_id = 1

--- a/groups/staffware-app/data.tf
+++ b/groups/staffware-app/data.tf
@@ -43,7 +43,14 @@ data "aws_security_group" "nagios_shared" {
   }
 }
 
-data "aws_security_group" "chips_weblogic" {
+data "aws_security_group" "chips_users_rest_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-users-rest-asg-*"]
+  }
+}
+
+data "aws_security_group" "chips_ef_batch_app" {
   filter {
     name   = "group-name"
     values = ["sgr-chips-ef-batch-asg-*"]

--- a/groups/staffware-db/data.tf
+++ b/groups/staffware-db/data.tf
@@ -14,11 +14,24 @@ data "aws_security_group" "nagios_shared" {
   }
 }
 
-
 data "aws_security_group" "iprocess_app" {
   filter {
     name   = "group-name"
     values = ["sgr-iprocess-app-asg-*"]
+  }
+}
+
+data "aws_security_group" "chips_users_rest_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-users-rest-asg-*"]
+  }
+}
+
+data "aws_security_group" "chips_ef_batch_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-ef-batch-asg-*"]
   }
 }
 

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -22,6 +22,20 @@ module "db_ec2_security_group" {
       protocol                 = "tcp"
       description              = "iProcess Application Security Group"
       source_security_group_id = data.aws_security_group.iprocess_app.id
+    },
+    {
+      from_port                = 1521
+      to_port                  = 1521
+      protocol                 = "tcp"
+      description              = "WebLogic chips-users-rest Application Security Group"
+      source_security_group_id = data.aws_security_group.chips_users_rest_app.id
+    },
+    {
+      from_port                = 1521
+      to_port                  = 1521
+      protocol                 = "tcp"
+      description              = "WebLogic chips-ef-batch Application Security Group"
+      source_security_group_id = data.aws_security_group.chips_ef_batch_app.id
     }
   ]
   ingress_with_cidr_blocks = [


### PR DESCRIPTION
Adds ingress rules to allow access fro CHIPS WebLogic app to the iProcess DB and application.

Resolves: https://companieshouse.atlassian.net/browse/CM-1169