### PR TITLE
Allow FES access to CHIPS ALB

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.107"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.111"
 
   application                      = var.application
   application_type                 = var.application_type

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.107"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.111"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.107"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.111"
 
   application                      = var.application
   application_type                 = "chips"


### PR DESCRIPTION
Reference 1.0.111 of terraform-modules to bring in security group changes to allow http/s access to CHIPS ALBs from application subnets.

Resolves: https://companieshouse.atlassian.net/browse/CM-1177