### PR TITLE
Adding EC2 cloudwatch alarms to each Oracle DB EC2 group, SNS only deployed to CHIPS and will be reused

### DIFF
--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -88,3 +88,64 @@ resource "aws_route53_record" "db_dns" {
   ttl     = "300"
   records = [aws_instance.db_ec2[count.index].private_ip]
 }
+
+module "cloudwatch-alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.112"
+  count  = var.db_instance_count
+
+  name_prefix               = "chips-oltp"
+  instance_id               = aws_instance.db_ec2[count.index].id
+  status_evaluation_periods = "3"
+  status_statistics_period  = "60"
+
+  cpuutilization_evaluation_periods = "2"
+  cpuutilization_statistics_period  = "60"
+  cpuutilization_threshold          = "75" # Percentage
+
+  enable_disk_alarms = true
+  disk_devices = [
+    {
+      instance_device_mount_path = "/"
+      instance_device_location   = "/dev/nvme0n1p2"
+      instance_device_fstype     = "xfs"
+    }
+  ]
+  disk_evaluation_periods = "3"
+  disk_statistics_period  = "120"
+  low_disk_threshold      = "75" # Percentage
+
+  enable_memory_alarms       = true
+  memory_evaluation_periods  = "2"
+  memory_statistics_period   = "120"
+  available_memory_threshold = "10" # Percentage
+  used_memory_threshold      = "80" # Percentage
+  used_swap_memory_threshold = "50" # Percentage
+
+  actions_alarm = [
+    module.cloudwatch_sns_notifications.this_sns_topic_arn
+  ]
+  actions_ok = [
+    module.cloudwatch_sns_notifications.this_sns_topic_arn
+  ]
+
+  depends_on = [
+    aws_instance.db_ec2,
+    module.cloudwatch_sns_notifications
+  ]
+
+  tags = merge(
+    local.default_tags,
+    tomap({
+      "ServiceTeam" = "Platforms/DBA",
+      "Terraform"   = true
+    })
+  )
+}
+
+
+
+
+
+
+
+

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -90,7 +90,7 @@ resource "aws_route53_record" "db_dns" {
 }
 
 module "cloudwatch-alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.112"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.117"
   count  = var.db_instance_count
 
   name_prefix               = "chips-oltp"

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -141,11 +141,3 @@ module "cloudwatch-alarms" {
     })
   )
 }
-
-
-
-
-
-
-
-

--- a/groups/chips-db/sns.tf
+++ b/groups/chips-db/sns.tf
@@ -1,0 +1,16 @@
+module "cloudwatch_sns_notifications" {
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name_prefix       = "${var.application}-cloudwatch-"
+  display_name      = "${var.application}-cloudwatch-alarms"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "DBA"
+    )
+  )
+}

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -90,7 +90,7 @@ resource "aws_route53_record" "db_dns" {
 }
 
 module "cloudwatch-alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.112"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.117"
 
   name_prefix               = "chips-rep"
   instance_id               = aws_instance.db_ec2.id

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -88,3 +88,55 @@ resource "aws_route53_record" "db_dns" {
   ttl     = "300"
   records = [aws_instance.db_ec2[count.index].private_ip]
 }
+
+module "cloudwatch-alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.112"
+
+  name_prefix               = "chips-rep"
+  instance_id               = aws_instance.db_ec2.id
+  status_evaluation_periods = "3"
+  status_statistics_period  = "60"
+
+  cpuutilization_evaluation_periods = "2"
+  cpuutilization_statistics_period  = "60"
+  cpuutilization_threshold          = "75" # Percentage
+
+  enable_disk_alarms = true
+  disk_devices = [
+    {
+      instance_device_mount_path = "/"
+      instance_device_location   = "/dev/nvme0n1p2"
+      instance_device_fstype     = "xfs"
+    }
+  ]
+  disk_evaluation_periods = "3"
+  disk_statistics_period  = "120"
+  low_disk_threshold      = "75" # Percentage
+
+  enable_memory_alarms       = true
+  memory_evaluation_periods  = "2"
+  memory_statistics_period   = "120"
+  available_memory_threshold = "10" # Percentage
+  used_memory_threshold      = "80" # Percentage
+  used_swap_memory_threshold = "50" # Percentage
+
+  actions_alarm = [
+    module.cloudwatch_sns_notifications.this_sns_topic_arn
+  ]
+  actions_ok = [
+    module.cloudwatch_sns_notifications.this_sns_topic_arn
+  ]
+
+  depends_on = [
+    aws_instance.db_ec2,
+    module.cloudwatch_sns_notifications
+  ]
+
+  tags = merge(
+    local.default_tags,
+    tomap({
+      "ServiceTeam" = "Platforms/DBA",
+      "Terraform"   = true
+    })
+  )
+}

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -112,7 +112,7 @@ resource "aws_route53_record" "db_dns" {
 }
 
 module "cloudwatch-alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.112"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.117"
 
   name_prefix               = "staffware"
   instance_id               = aws_instance.db_ec2.id

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -110,3 +110,55 @@ resource "aws_route53_record" "db_dns" {
   ttl     = "300"
   records = [aws_instance.db_ec2[count.index].private_ip]
 }
+
+module "cloudwatch-alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/ec2-cloudwatch-alarms?ref=tags/1.0.112"
+
+  name_prefix               = "staffware"
+  instance_id               = aws_instance.db_ec2.id
+  status_evaluation_periods = "3"
+  status_statistics_period  = "60"
+
+  cpuutilization_evaluation_periods = "2"
+  cpuutilization_statistics_period  = "60"
+  cpuutilization_threshold          = "75" # Percentage
+
+  enable_disk_alarms = true
+  disk_devices = [
+    {
+      instance_device_mount_path = "/"
+      instance_device_location   = "/dev/nvme0n1p2"
+      instance_device_fstype     = "xfs"
+    }
+  ]
+  disk_evaluation_periods = "3"
+  disk_statistics_period  = "120"
+  low_disk_threshold      = "75" # Percentage
+
+  enable_memory_alarms       = true
+  memory_evaluation_periods  = "2"
+  memory_statistics_period   = "120"
+  available_memory_threshold = "10" # Percentage
+  used_memory_threshold      = "80" # Percentage
+  used_swap_memory_threshold = "50" # Percentage
+
+  actions_alarm = [
+    module.cloudwatch_sns_notifications.this_sns_topic_arn
+  ]
+  actions_ok = [
+    module.cloudwatch_sns_notifications.this_sns_topic_arn
+  ]
+
+  depends_on = [
+    aws_instance.db_ec2,
+    module.cloudwatch_sns_notifications
+  ]
+
+  tags = merge(
+    local.default_tags,
+    tomap({
+      "ServiceTeam" = "Platforms/DBA",
+      "Terraform"   = true
+    })
+  )
+}


### PR DESCRIPTION
Adding EC2 cloudwatch alarms to each Oracle DB EC2 group, SNS only deployed to CHIPS and will be reused