### PR TITLE
Increase tux-proxy instances size

### DIFF
--- a/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
@@ -13,7 +13,7 @@ environment = "live"
 
 # ASG settings
 asg_count = 2
-instance_size = "t3.medium"
+instance_size = "t3.large"
 
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"

--- a/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
@@ -13,7 +13,7 @@ environment = "staging"
 
 # ASG settings
 asg_count = 2
-instance_size = "t3.medium"
+instance_size = "t3.large"
 
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"


### PR DESCRIPTION
We have noticed that the proxies are getting restarted and that the EC2 instance is low on memory.  This changes the instance from a t3.medium to a t3.large.
t3.large has the same vCPUs but double the memory, so there is no additional WL licensing cost.