### PR TITLE
chips db failover run book

### DIFF
--- a/groups/chips-db/ssm.tf
+++ b/groups/chips-db/ssm.tf
@@ -115,3 +115,29 @@ resource "aws_ssm_maintenance_window_target" "target" {
   }
   # owner_information - (Optional) User-provided value that will be included in any CloudWatch events raised while running tasks for these targets in this Maintenance Window.
 }
+
+
+################################################################################
+## DB Failover Runbook Doc
+################################################################################
+
+resource "aws_ssm_document" "failover-db" {
+  name            = "ch-ssm-failover-chips-db"
+  document_type   = "Automation"
+  document_format = "YAML"
+  content = templatefile("templates/chips-db-failover-ssm-document.yaml",
+    {
+      execution_role         = module.ssm-runbook-execution-role.iam_role_arn
+      region_name            = var.aws_region
+      chips_db_instance_name = "${var.application}-db-*"
+      command_document_name  = "ch-ssm-run-ansible"
+    }
+  )
+  tags = merge(
+    local.default_tags,
+    map(
+      "Account", var.aws_account,
+      "ServiceTeam", "Platforms"
+    )
+  )
+}

--- a/groups/chips-db/templates/chips-db-failover-ssm-document.yaml
+++ b/groups/chips-db/templates/chips-db-failover-ssm-document.yaml
@@ -1,0 +1,67 @@
+description: 'Upon triggering by EventBridge, select a Chips DB Instance ID to failover to, wait until it comes up and then execute an Ansible configuration against the newly started Instance.'
+schemaVersion: '0.3'
+assumeRole: '${execution_role}'
+parameters:
+  triggeringInstance:
+    type: String
+mainSteps:
+  - name: select_failover_instance
+    action: 'aws:executeScript'
+    outputs:
+      - Name: id
+        Selector: $.Payload
+        Type: String
+    inputs:
+      Runtime: python3.6
+      Handler: script_handler
+      Script: |-
+        def script_handler(events, context):
+          import boto3
+        
+          triggering_instance = events['triggering_instance']  
+          ec2 = boto3.client('ec2', region_name='${region_name}')
+
+          chips_db_instances = ec2.describe_instances(
+              Filters=[
+                  {
+                      'Name': 'tag:Name',
+                      'Values': [
+                          '${chips_db_instance_name}',
+                      ]
+                  }
+              ]
+          )
+        
+          # Assumes only ever two instances running, pick up ID that is not that of the triggering instance.
+          for reservation in chips_db_instances['Reservations']:
+              for instance in reservation['Instances']:
+                  if instance['InstanceId'] != triggering_instance:
+                      failover_id = instance['InstanceId']
+                      return failover_id
+
+      InputPayload:
+        triggering_instance: '{{ triggeringInstance }}'
+  - name: start_failover_instance
+    action: 'aws:changeInstanceState'
+    inputs:
+      DesiredState: running
+      InstanceIds:
+        - '{{select_failover_instance.id}}'
+  - name: wait
+    action: 'aws:waitForAwsResourceProperty'
+    inputs:
+      Service: ssm
+      Api: DescribeInstanceInformation
+      PropertySelector: '[InstanceInformationList][0][PingStatus]'
+      DesiredValues:
+        - Online
+      InstanceInformationFilterList:
+        - key: InstanceIds
+          valueSet:
+            - '{{select_failover_instance.id}}'
+  - name: trigger_configuration
+    action: 'aws:runCommand'
+    inputs:
+      DocumentName: ${command_document_name}
+      InstanceIds:
+        - '{{select_failover_instance.id}}'


### PR DESCRIPTION
templated ssm document added to produce SSM Automation RunBook to power on the failover chips DB instance, wait for availability and then trigger a configuration command document.

execution role provided with minimal permissions