### PR TITLE
Add ingress rules for direct http & t3s traffic to WebLogic nodes

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -54,6 +54,20 @@ module "chips-ef-batch" {
       protocol    = "tcp"
       description = "Tuxedo ports"
       cidr_blocks = join(",", [for s in module.chips-ef-batch.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21010
+      to_port     = 21014
+      protocol    = "tcp"
+      description = "WebLogic HTTP ports"
+      cidr_blocks = join(",", [for s in module.chips-ef-batch.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21030
+      to_port     = 21034
+      protocol    = "tcp"
+      description = "WebLogic t3s ports"
+      cidr_blocks = join(",", [for s in module.chips-ef-batch.application_subnets : s.cidr_block])
     }
   ]
 

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -55,6 +55,13 @@ module "chips-tux-proxy" {
       protocol    = "tcp"
       description = "Tuxedo proxy ports"
       cidr_blocks = join(",", [for s in module.chips-tux-proxy.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21010
+      to_port     = 21011
+      protocol    = "tcp"
+      description = "WebLogic HTTP ports"
+      cidr_blocks = join(",", [for s in module.chips-tux-proxy.application_subnets : s.cidr_block])
     }
   ]
 

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -54,6 +54,20 @@ module "chips-users-rest" {
       protocol    = "tcp"
       description = "Tuxedo ports"
       cidr_blocks = join(",", [for s in module.chips-users-rest.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21010
+      to_port     = 21014
+      protocol    = "tcp"
+      description = "WebLogic HTTP ports"
+      cidr_blocks = join(",", [for s in module.chips-users-rest.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21030
+      to_port     = 21034
+      protocol    = "tcp"
+      description = "WebLogic t3s ports"
+      cidr_blocks = join(",", [for s in module.chips-users-rest.application_subnets : s.cidr_block])
     }
   ]
 


### PR DESCRIPTION
Allow ingress to http and t3s ports on WebLogic from within the application subnets, to allow for monitoring, analytics and comms between clusters.

Resolves: https://companieshouse.atlassian.net/browse/CM-1123