### PR TITLE
Add chips-read-only group

### DIFF
--- a/groups/chips-read-only/data.tf
+++ b/groups/chips-read-only/data.tf
@@ -1,0 +1,3 @@
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
+}

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 0.3, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 2.0.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}
+
+module "chips-read-only" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.126"
+
+  application                      = var.application
+  application_type                 = "chips"
+  aws_region                       = var.aws_region
+  aws_account                      = var.aws_account
+  account                          = var.account
+  region                           = var.region
+  environment                      = var.environment
+  asg_count                        = var.asg_count
+  instance_size                    = var.instance_size
+  enable_instance_refresh          = var.enable_instance_refresh
+  nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
+  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+  cloudwatch_logs                  = var.cloudwatch_logs
+  config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
+  alb_idle_timeout                 = 180
+  enable_sns_topic                 = var.enable_sns_topic
+  create_app_target_group          = false
+
+  additional_ingress_with_cidr_blocks = [
+    {
+      from_port   = 49075
+      to_port     = 49078
+      protocol    = "tcp"
+      description = "Tuxedo ports"
+      cidr_blocks = join(",", [for s in module.chips-read-only.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21010
+      to_port     = 21014
+      protocol    = "tcp"
+      description = "WebLogic HTTP ports"
+      cidr_blocks = join(",", [for s in module.chips-read-only.application_subnets : s.cidr_block])
+    },
+    {
+      from_port   = 21030
+      to_port     = 21034
+      protocol    = "tcp"
+      description = "WebLogic t3s ports"
+      cidr_blocks = join(",", [for s in module.chips-read-only.application_subnets : s.cidr_block])
+    }
+  ]
+
+  additional_userdata_suffix = <<-EOT
+  su -l ec2-user weblogic-pre-bootstrap.sh
+  su -l ec2-user bootstrap
+  EOT
+}

--- a/groups/chips-read-only/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-development-eu-west-2/vars
@@ -1,0 +1,172 @@
+# Account details
+aws_profile = "heritage-development-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-development"
+
+# Account shorthand
+account = "hdev"
+region  = "euw2"
+
+# Application details
+application = "chips-read-only"
+environment = "development"
+
+# ASG settings
+asg_count = 1
+instance_size = "t3.large"
+enable_instance_refresh = true
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+############################################
+# Log entries to be aggregated in Cloudwatch Logs
+# 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )
+############################################
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 7
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 7
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
+}

--- a/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
@@ -1,0 +1,174 @@
+# Account details
+aws_profile = "heritage-live-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-live"
+
+# Account shorthand
+account = "hlive"
+region  = "euw2"
+
+# Application details
+application = "chips-read-only"
+environment = "live"
+
+# ASG settings
+asg_count = 2
+instance_size = "t3.large"
+
+# SNS Topic creation
+enable_sns_topic = true
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+############################################
+# Log entries to be aggregated in Cloudwatch Logs
+# 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )
+############################################
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 180
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 180
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 180
+  }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 180
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 180
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 180
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 180
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 180
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 180
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 180
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 180
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 180
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 180
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 180
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 180
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 180
+  }
+}

--- a/groups/chips-read-only/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-staging-eu-west-2/vars
@@ -1,0 +1,174 @@
+# Account details
+aws_profile = "heritage-staging-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-staging"
+
+# Account shorthand
+account = "hstg"
+region  = "euw2"
+
+# Application details
+application = "chips-read-only"
+environment = "staging"
+
+# ASG settings
+asg_count = 2
+instance_size = "t3.large"
+
+# SNS Topic creation
+enable_sns_topic = true
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+############################################
+# Log entries to be aggregated in Cloudwatch Logs
+# 'NFSPATH' file_path in file_path keys will be templated with the full path to the application instances mounted share folder (e.g. /mnt/nfs/cics/cics1 )
+############################################
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+
+  "apache-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "apache-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "error.log"
+    log_group_retention = 7
+  }
+
+  "apache-admin-access" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-access.log"
+    log_group_retention = 7
+  }
+	
+  "apache-admin-error" = {
+    file_path = "NFSPATH/running-servers/apache"
+    file_name = "admin-error.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-access" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-log" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.log"
+    log_group_retention = 7
+  }
+
+  "wlserver1-out" = {
+    file_path = "NFSPATH/running-servers/wlserver1/logs"
+    file_name = "wlserver1.out"
+    log_group_retention = 7
+  }
+
+  "wlserver2-access" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-log" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.log"
+    log_group_retention = 7
+  }
+
+  "wlserver2-out" = {
+    file_path = "NFSPATH/running-servers/wlserver2/logs"
+    file_name = "wlserver2.out"
+    log_group_retention = 7
+  }
+
+  "wlserver3-access" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-log" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.log"
+    log_group_retention = 7
+  }
+
+  "wlserver3-out" = {
+    file_path = "NFSPATH/running-servers/wlserver3/logs"
+    file_name = "wlserver3.out"
+    log_group_retention = 7
+  }
+
+  "wlserver4-access" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-log" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.log"
+    log_group_retention = 7
+  }
+
+  "wlserver4-out" = {
+    file_path = "NFSPATH/running-servers/wlserver4/logs"
+    file_name = "wlserver4.out"
+    log_group_retention = 7
+  }
+
+  "wladmin-access" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "access.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-log" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "wladmin.log"
+    log_group_retention = 7
+  }
+
+  "wladmin-chipsdomain" = {
+    file_path = "NFSPATH/running-servers/wladmin/logs"
+    file_name = "chipsdomain.out"
+    log_group_retention = 7
+  }
+}

--- a/groups/chips-read-only/variables.tf
+++ b/groups/chips-read-only/variables.tf
@@ -1,0 +1,183 @@
+# ------------------------------------------------------------------------------
+# Vault Variables
+# ------------------------------------------------------------------------------
+variable "vault_username" {
+  type        = string
+  description = "Username for connecting to Vault - usually supplied through TF_VARS"
+}
+
+variable "vault_password" {
+  type        = string
+  description = "Password for connecting to Vault - usually supplied through TF_VARS"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables
+# ------------------------------------------------------------------------------
+variable "aws_region" {
+  type        = string
+  description = "The AWS region in which resources will be administered"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "The AWS profile to use"
+}
+
+variable "aws_account" {
+  type        = string
+  description = "The name of the AWS Account in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables - Shorthand
+# ------------------------------------------------------------------------------
+
+variable "account" {
+  type        = string
+  description = "Short version of the name of the AWS Account in which resources will be administered"
+}
+
+variable "region" {
+  type        = string
+  description = "Short version of the name of the AWS region in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+variable "application" {
+  type        = string
+  description = "The component name of the application"
+}
+
+variable "environment" {
+  type        = string
+  description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
+}
+
+# ------------------------------------------------------------------------------
+# CHIPS ASG Variables
+# ------------------------------------------------------------------------------
+
+variable "instance_size" {
+  type        = string
+  description = "The size of the ec2 instances to build"
+}
+
+variable "asg_min_size" {
+  type        = number
+  default     = 1
+  description = "The min size of the ASG - always 1"
+}
+
+variable "asg_max_size" {
+  type        = number
+  default     = 1
+  description = "The max size of the ASG - always 1"
+}
+
+variable "asg_desired_capacity" {
+  type        = number
+  default     = 1
+  description = "The desired capacity of ASG - always 1"
+}
+
+variable "asg_count" {
+  type        = number
+  description = "The number of ASGs - typically 1 for dev and 2 for staging/live"
+}
+
+variable "ami_name" {
+  type        = string
+  default     = "docker-ami-*"
+  description = "Name of the AMI to use in the Auto Scaling configuration"
+}
+
+variable "instance_root_volume_size" {
+  type        = number
+  default     = 40
+  description = "Size of root volume attached to instances"
+}
+
+variable "alb_deletion_protection" {
+  type        = bool
+  default     = false
+  description = "Enable or disable deletion protection for instances"
+}
+
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
+
+# ------------------------------------------------------------------------------
+# CHIPS ALB Variables
+# ------------------------------------------------------------------------------
+
+variable "application_port" {
+  type        = number
+  default     = 21000
+  description = "Target group backend port for application"
+}
+
+variable "admin_port" {
+  type        = number
+  default     = 21001
+  description = "Target group backend port for administration"
+}
+
+variable "app_health_check_path" {
+  type        = string
+  default     = "/"
+  description = "Target group health check path for application"
+}
+
+variable "admin_health_check_path" {
+  type        = string
+  default     = "/console"
+  description = "Target group health check path for administration console"
+}
+
+variable "domain_name" {
+  type        = string
+  default     = "*.companieshouse.gov.uk"
+  description = "Domain Name for ACM Certificate"
+}
+
+# ------------------------------------------------------------------------------
+# NFS Mount Variables
+# ------------------------------------------------------------------------------
+# See Ansible role for full documentation on NFS arguements:
+#      https://github.com/companieshouse/ansible-collections/tree/main/ch_collections/heritage_services/roles/nfs/files/nfs_mounts
+variable "nfs_mount_destination_parent_dir" {
+  type        = string
+  description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
+  default     = "/mnt"
+}
+
+variable "default_log_group_retention_in_days" {
+  type        = number
+  default     = 14
+  description = "Total days to retain logs in CloudWatch log group if not specified for specific logs"
+}
+
+variable "cloudwatch_logs" {
+  type        = map(any)
+  description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
+  default     = {}
+}
+
+variable "enable_sns_topic" {
+  type        = bool
+  description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
+  default     = false
+}

--- a/groups/chips-read-only/version
+++ b/groups/chips-read-only/version
@@ -1,0 +1,1 @@
+chips-read-only-0.1


### PR DESCRIPTION
Updated the chips-terraform to include a new group for the chips-read-only cluster.  This cluster is to support tuxedo READ calls against the REP DB using a read only DB user.

Resolves: https://companieshouse.atlassian.net/browse/CM-1335
