### PR TITLE
Correct the ASG count to 1 for staging and live

### DIFF
--- a/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
@@ -12,7 +12,7 @@ application = "chips-read-only"
 environment = "live"
 
 # ASG settings
-asg_count = 2
+asg_count = 1
 instance_size = "t3.large"
 
 # SNS Topic creation

--- a/groups/chips-read-only/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-staging-eu-west-2/vars
@@ -12,7 +12,7 @@ application = "chips-read-only"
 environment = "staging"
 
 # ASG settings
-asg_count = 2
+asg_count = 1
 instance_size = "t3.large"
 
 # SNS Topic creation


### PR DESCRIPTION
There should only be one instance in this cluster, as it will only be used occasionally for short periods, so having 2 instances would be wasteful.

Resolves: https://companieshouse.atlassian.net/browse/CM-1335