### PR TITLE
AWS forced usage of ssm param value for runCommand downloads from Github

### DIFF
--- a/groups/chips-db/locals.tf
+++ b/groups/chips-db/locals.tf
@@ -58,7 +58,29 @@ locals {
       repository = var.ansible_ssm_git_repo_name
       path       = var.ansible_ssm_git_repo_path
       getOptions = var.ansible_ssm_git_repo_options
-      tokenInfo  = local.ssm_data.ssm_github_token
+      tokenInfo  = "{{ssm-secure:${aws_ssm_parameter.github.name}}}"
+    })
+
+    InstallDependencies = "False"
+    InstallRequirements = "True"
+    PlaybookFile        = var.ssm_playbook_file_name
+    RequirementsFile    = var.ssm_requirements_file_name
+
+    ExtraVariables     = "SSM=True" #space separated vars
+    ExtraVariablesJson = jsonencode(local.ansible_inputs)
+    Check              = "True"
+    Verbose            = var.ansible_ssm_verbose_level
+    TimeoutSeconds     = "3600"
+  }
+
+  failover_ssm_parameters = {
+    SourceType = "GitHub"
+    SourceInfo = jsonencode({
+      owner      = var.ansible_ssm_git_repo_owner
+      repository = var.ansible_ssm_git_repo_name
+      path       = var.ansible_ssm_git_repo_path
+      getOptions = var.ansible_ssm_git_repo_options
+      tokenInfo  = null
     })
 
     InstallDependencies = "False"

--- a/groups/chips-db/ssm.tf
+++ b/groups/chips-db/ssm.tf
@@ -48,6 +48,17 @@ resource "aws_ssm_association" "ansible_apply" {
 }
 
 ################################################################################
+## Github token secret for SSM Ansible
+################################################################################
+# Known bug that this changes on every plan/apply: https://github.com/hashicorp/terraform-provider-aws/issues/21095
+resource "aws_ssm_parameter" "github" {
+  name  = "github-token"
+  type  = "SecureString"
+  value = local.ssm_data.ssm_github_token
+}
+
+
+################################################################################
 ## Maintenance window, sets up a time period where operations can be ran
 ################################################################################
 resource "aws_ssm_maintenance_window" "maintenance_window" {
@@ -86,7 +97,7 @@ resource "aws_ssm_document" "failover_db" {
       region_name                 = var.aws_region
       db_instance_name            = "${var.application}-db-*"
       command_document_name       = "ch-ssm-run-ansible"
-      command_document_parameters = indent(8, yamlencode(merge(local.ansible_ssm_parameters, { Check = "False" })))
+      command_document_parameters = indent(8, yamlencode(merge(local.failover_ssm_parameters, { Check = "False" })))
       dns_name                    = aws_route53_record.dns_cname.name
       route53_zone                = data.aws_route53_zone.private_zone.zone_id
       failover_approvers          = indent(8, yamlencode(local.failover_approvers))

--- a/groups/chips-rep-db/locals.tf
+++ b/groups/chips-rep-db/locals.tf
@@ -55,7 +55,29 @@ locals {
       repository = var.ansible_ssm_git_repo_name
       path       = var.ansible_ssm_git_repo_path
       getOptions = var.ansible_ssm_git_repo_options
-      tokenInfo  = local.ssm_data.ssm_github_token
+      tokenInfo  = "{{ssm-secure:${aws_ssm_parameter.github.name}}}"
+    })
+
+    InstallDependencies = "False"
+    InstallRequirements = "True"
+    PlaybookFile        = var.ssm_playbook_file_name
+    RequirementsFile    = var.ssm_requirements_file_name
+
+    ExtraVariables     = "SSM=True" #space separated vars
+    ExtraVariablesJson = jsonencode(local.ansible_inputs)
+    Check              = "True"
+    Verbose            = var.ansible_ssm_verbose_level
+    TimeoutSeconds     = "3600"
+  }
+
+  failover_ssm_parameters = {
+    SourceType = "GitHub"
+    SourceInfo = jsonencode({
+      owner      = var.ansible_ssm_git_repo_owner
+      repository = var.ansible_ssm_git_repo_name
+      path       = var.ansible_ssm_git_repo_path
+      getOptions = var.ansible_ssm_git_repo_options
+      tokenInfo  = null
     })
 
     InstallDependencies = "False"

--- a/groups/chips-rep-db/ssm.tf
+++ b/groups/chips-rep-db/ssm.tf
@@ -48,6 +48,15 @@ resource "aws_ssm_association" "ansible_apply" {
 }
 
 ################################################################################
+## Github token secret for SSM Ansible
+################################################################################
+resource "aws_ssm_parameter" "github" {
+  name  = "github-token"
+  type  = "SecureString"
+  value = local.ssm_data.ssm_github_token
+}
+
+################################################################################
 ## Maintenance window, sets up a time period where operations can be ran
 ################################################################################
 resource "aws_ssm_maintenance_window" "maintenance_window" {
@@ -84,7 +93,7 @@ resource "aws_ssm_document" "failover_db" {
       region_name                 = var.aws_region
       db_instance_name            = "${var.application}-db-*"
       command_document_name       = "ch-ssm-run-ansible"
-      command_document_parameters = indent(8, yamlencode(merge(local.ansible_ssm_parameters, { Check = "False" })))
+      command_document_parameters = indent(8, yamlencode(merge(local.failover_ssm_parameters, { Check = "False" })))
       dns_name                    = aws_route53_record.dns_cname.name
       route53_zone                = data.aws_route53_zone.private_zone.zone_id
       failover_approvers          = indent(8, yamlencode(local.failover_approvers))

--- a/groups/staffware-db/locals.tf
+++ b/groups/staffware-db/locals.tf
@@ -52,7 +52,29 @@ locals {
       repository = var.ansible_ssm_git_repo_name
       path       = var.ansible_ssm_git_repo_path
       getOptions = var.ansible_ssm_git_repo_options
-      tokenInfo  = local.ssm_data.ssm_github_token
+      tokenInfo  = "{{ssm-secure:${aws_ssm_parameter.github.name}}}"
+    })
+
+    InstallDependencies = "False"
+    InstallRequirements = "True"
+    PlaybookFile        = var.ssm_playbook_file_name
+    RequirementsFile    = var.ssm_requirements_file_name
+
+    ExtraVariables     = "SSM=True" #space separated vars
+    ExtraVariablesJson = jsonencode(local.ansible_inputs)
+    Check              = "True"
+    Verbose            = var.ansible_ssm_verbose_level
+    TimeoutSeconds     = "3600"
+  }
+
+  failover_ssm_parameters = {
+    SourceType = "GitHub"
+    SourceInfo = jsonencode({
+      owner      = var.ansible_ssm_git_repo_owner
+      repository = var.ansible_ssm_git_repo_name
+      path       = var.ansible_ssm_git_repo_path
+      getOptions = var.ansible_ssm_git_repo_options
+      tokenInfo  = null
     })
 
     InstallDependencies = "False"

--- a/groups/staffware-db/ssm.tf
+++ b/groups/staffware-db/ssm.tf
@@ -49,6 +49,15 @@ resource "aws_ssm_association" "ansible_apply" {
 }
 
 ################################################################################
+## Github token secret for SSM Ansible
+################################################################################
+resource "aws_ssm_parameter" "github" {
+  name  = "github-token"
+  type  = "SecureString"
+  value = local.ssm_data.ssm_github_token
+}
+
+################################################################################
 ## Maintenance window, sets up a time period where operations can be ran
 ################################################################################
 resource "aws_ssm_maintenance_window" "maintenance_window" {
@@ -85,7 +94,7 @@ resource "aws_ssm_document" "failover_db" {
       region_name                 = var.aws_region
       db_instance_name            = "${var.application}-db-*"
       command_document_name       = "ch-ssm-run-ansible"
-      command_document_parameters = indent(8, yamlencode(merge(local.ansible_ssm_parameters, { Check = "False" })))
+      command_document_parameters = indent(8, yamlencode(merge(local.failover_ssm_parameters, { Check = "False" })))
       dns_name                    = aws_route53_record.dns_cname.name
       route53_zone                = data.aws_route53_zone.private_zone.zone_id
       failover_approvers          = indent(8, yamlencode(local.failover_approvers))


### PR DESCRIPTION
AWS forced usage of ssm param value for runCommand downloads from Github so reverting to use that, failover set to null as it should still work but rate limits apply