### PR TITLE
Update referenced version of terraform-modules to 1.0.163

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.126"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.163"
 
   application                      = var.application
   application_type                 = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.126"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.163"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.126"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.163"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.126"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.163"
 
   application                      = var.application
   application_type                 = "chips"
@@ -46,6 +46,7 @@ module "chips-users-rest" {
   config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
   alb_idle_timeout                 = 180
   enable_sns_topic                 = var.enable_sns_topic
+  create_nlb                       = true
 
   additional_ingress_with_cidr_blocks = [
     {


### PR DESCRIPTION
This pulls in the change to add an NLB in front the ALB in order to provide static IPs to allow NAT access from call centre network.

The NLB is only created if the module var create_nlb = true, and it is not created by default. The intention is to just create this for the chips-users-rest cluster.

Resolves: https://companieshouse.atlassian.net/browse/CM-1374
