### PR TITLE
Create CloudWatch Log Groups for Oracle Logs

### DIFF
--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -206,3 +206,19 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_groups" {
     })
   )
 }
+
+resource "aws_cloudwatch_log_group" "cloudwatch_oracle_log_groups" {
+  count = length(var.cloudwatch_oracle_log_groups) > 0 ? length(var.cloudwatch_oracle_log_groups) : 0
+
+  name              = var.cloudwatch_oracle_log_groups[count.index]
+  retention_in_days = var.default_log_group_retention_in_days
+  kms_key_id        = local.logs_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    tomap({
+      "ServiceTeam" = "Platforms/DBA",
+      "Terraform"   = true
+    })
+  )
+}

--- a/groups/chips-db/iam.tf
+++ b/groups/chips-db/iam.tf
@@ -21,12 +21,12 @@ module "db_instance_profile" {
       "arn:aws:logs:%s:%s:log-group:%s:*:*",
       var.aws_region,
       data.aws_caller_identity.current.account_id,
-      local.log_groups
+      concat(local.log_groups, var.cloudwatch_oracle_log_groups)
     ),
     formatlist("arn:aws:logs:%s:%s:log-group:%s:*",
       var.aws_region,
       data.aws_caller_identity.current.account_id,
-      local.log_groups
+      concat(local.log_groups, var.cloudwatch_oracle_log_groups)
     ),
   ]) : null
 

--- a/groups/chips-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-live-eu-west-2/vars
@@ -72,6 +72,12 @@ cloudwatch_logs = {
   }
 }
 
+cloudwatch_oracle_log_groups = [
+  "chips-oltp-db/oracle/alert",
+  "chips-oltp-db/oracle/audit",
+  "chips-oltp-db/oracle/listener",
+  "chips-oltp-db/oracle/trace"
+]
 
 ansible_ssm_git_repo_name = "oracle-12-ami"
 ansible_ssm_git_repo_owner = "companieshouse"

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -72,6 +72,12 @@ cloudwatch_logs = {
   }
 }
 
+cloudwatch_oracle_log_groups = [
+  "chips-oltp-db/oracle/alert",
+  "chips-oltp-db/oracle/audit",
+  "chips-oltp-db/oracle/listener",
+  "chips-oltp-db/oracle/trace"
+]
 
 ansible_ssm_git_repo_name = "oracle-12-ami"
 ansible_ssm_git_repo_owner = "companieshouse"

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -111,6 +111,12 @@ variable "cloudwatch_logs" {
   description = "Map of log files to be collected by Cloudwatch Logs"
 }
 
+variable "cloudwatch_oracle_log_groups" {
+  type        = list(string)
+  default     = []
+  description = "A list of CloudWatch Log Groups that will be used to receive Oracle log data"
+}
+
 variable "cloudwatch_namespace" {
   type        = string
   default     = null

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -183,3 +183,19 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_groups" {
     })
   )
 }
+
+resource "aws_cloudwatch_log_group" "cloudwatch_oracle_log_groups" {
+  count = length(var.cloudwatch_oracle_log_groups) > 0 ? length(var.cloudwatch_oracle_log_groups) : 0
+
+  name              = var.cloudwatch_oracle_log_groups[count.index]
+  retention_in_days = var.default_log_group_retention_in_days
+  kms_key_id        = local.logs_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    tomap({
+      "ServiceTeam" = "Platforms/DBA",
+      "Terraform"   = true
+    })
+  )
+}

--- a/groups/chips-rep-db/iam.tf
+++ b/groups/chips-rep-db/iam.tf
@@ -21,12 +21,12 @@ module "db_instance_profile" {
       "arn:aws:logs:%s:%s:log-group:%s:*:*",
       var.aws_region,
       data.aws_caller_identity.current.account_id,
-      local.log_groups
+      concat(local.log_groups, var.cloudwatch_oracle_log_groups)
     ),
     formatlist("arn:aws:logs:%s:%s:log-group:%s:*",
       var.aws_region,
       data.aws_caller_identity.current.account_id,
-      local.log_groups
+      concat(local.log_groups, var.cloudwatch_oracle_log_groups)
     ),
   ]) : null
 

--- a/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
@@ -72,6 +72,13 @@ cloudwatch_logs = {
   }
 }
 
+cloudwatch_oracle_log_groups = [
+  "chips-rep-db/oracle/alert",
+  "chips-rep-db/oracle/audit",
+  "chips-rep-db/oracle/listener",
+  "chips-rep-db/oracle/trace"
+]
+
 ansible_ssm_git_repo_name = "oracle-12-ami"
 ansible_ssm_git_repo_owner = "companieshouse"
 ansible_ssm_git_repo_path = "ansible/"

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -72,6 +72,13 @@ cloudwatch_logs = {
   }
 }
 
+cloudwatch_oracle_log_groups = [
+  "chips-rep-db/oracle/alert",
+  "chips-rep-db/oracle/audit",
+  "chips-rep-db/oracle/listener",
+  "chips-rep-db/oracle/trace"
+]
+
 ansible_ssm_git_repo_name = "oracle-12-ami"
 ansible_ssm_git_repo_owner = "companieshouse"
 ansible_ssm_git_repo_path = "ansible/"

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -141,6 +141,12 @@ variable "cloudwatch_logs" {
   description = "Map of log files to be collected by Cloudwatch Logs"
 }
 
+variable "cloudwatch_oracle_log_groups" {
+  type        = list(string)
+  default     = []
+  description = "A list of CloudWatch Log Groups that will be used to receive Oracle log data"
+}
+
 variable "cloudwatch_namespace" {
   type        = string
   default     = null

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -182,3 +182,19 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_groups" {
     })
   )
 }
+
+resource "aws_cloudwatch_log_group" "cloudwatch_oracle_log_groups" {
+  count = length(var.cloudwatch_oracle_log_groups) > 0 ? length(var.cloudwatch_oracle_log_groups) : 0
+
+  name              = var.cloudwatch_oracle_log_groups[count.index]
+  retention_in_days = var.default_log_group_retention_in_days
+  kms_key_id        = local.logs_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    tomap({
+      "ServiceTeam" = "Platforms/DBA",
+      "Terraform"   = true
+    })
+  )
+}

--- a/groups/staffware-db/iam.tf
+++ b/groups/staffware-db/iam.tf
@@ -21,12 +21,12 @@ module "db_instance_profile" {
       "arn:aws:logs:%s:%s:log-group:%s:*:*",
       var.aws_region,
       data.aws_caller_identity.current.account_id,
-      local.log_groups
+      concat(local.log_groups, var.cloudwatch_oracle_log_groups)
     ),
     formatlist("arn:aws:logs:%s:%s:log-group:%s:*",
       var.aws_region,
       data.aws_caller_identity.current.account_id,
-      local.log_groups
+      concat(local.log_groups, var.cloudwatch_oracle_log_groups)
     ),
   ]) : null
 

--- a/groups/staffware-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-live-eu-west-2/vars
@@ -57,6 +57,13 @@ cloudwatch_logs = {
   }
 }
 
+cloudwatch_oracle_log_groups = [
+  "staffware-db/oracle/alert",
+  "staffware-db/oracle/audit",
+  "staffware-db/oracle/listener",
+  "staffware-db/oracle/trace"
+]
+
 ansible_ssm_git_repo_name = "oracle-12-ami"
 ansible_ssm_git_repo_owner = "companieshouse"
 ansible_ssm_git_repo_path = "ansible/"

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -57,6 +57,13 @@ cloudwatch_logs = {
   }
 }
 
+cloudwatch_oracle_log_groups = [
+  "staffware-db/oracle/alert",
+  "staffware-db/oracle/audit",
+  "staffware-db/oracle/listener",
+  "staffware-db/oracle/trace"
+]
+
 ansible_ssm_git_repo_name = "oracle-12-ami"
 ansible_ssm_git_repo_owner = "companieshouse"
 ansible_ssm_git_repo_path = "ansible/"

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -111,6 +111,12 @@ variable "cloudwatch_logs" {
   description = "Map of log files to be collected by Cloudwatch Logs"
 }
 
+variable "cloudwatch_oracle_log_groups" {
+  type        = list(string)
+  default     = []
+  description = "A list of CloudWatch Log Groups that will be used to receive Oracle log data"
+}
+
 variable "cloudwatch_namespace" {
   type        = string
   default     = null


### PR DESCRIPTION
Added config to define and create CloudWatch log groups in readiness to receive Oracle DB logs

Added list variable to define the log groups by name
Added new `aws_cloudwatch_log_group` resource to create the log groups defined in the list
Updated the `db_instance_profile` module to include the Oracle log group names in the instance IAM policy