### PR TITLE
Add RDS CloudWatch Alarms

### DIFF
--- a/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
@@ -109,3 +109,8 @@ parameter_group_settings = [
       value = "AUTO"
     },
 ]
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/chips-rds/rds.tf
+++ b/groups/chips-rds/rds.tf
@@ -95,6 +95,10 @@ module "chips_rds" {
       option_name = "JVM"
     },
     {
+      option_name = "S3_INTEGRATION"
+      version     = "1.0"
+    },
+    {
       option_name = "SQLT"
       version     = "2018-07-25.v1"
       option_settings = [
@@ -127,4 +131,14 @@ module "chips_rds" {
       "ServiceTeam", "${upper(var.identifier)}-DBA-Support"
     )
   )
+}
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  rds_instance_id        = module.chips_rds.this_db_instance_id
+  rds_instance_shortname = upper(var.name)
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }

--- a/groups/chips-rds/variables.tf
+++ b/groups/chips-rds/variables.tf
@@ -149,3 +149,21 @@ variable "auto_minor_version_upgrade" {
   description = "True/False value to allow AWS to apply minor version updates to RDS without approval from owner"
   default     = true
 }
+
+# ------------------------------------------------------------------------------
+# RDS CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = string
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}


### PR DESCRIPTION
Added module config to deploy standard RDS CloudWatch alarms
Added supporting variables
Defined `S3_INTEGRATION` RDS option that was added outside of Terraform