### PR TITLE
Allow Concourse Deployment Connectivity

### DIFF
--- a/groups/chips-db/data.tf
+++ b/groups/chips-db/data.tf
@@ -58,16 +58,20 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "onprem_app_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/onprem_app_cidrs"
+}
+
+data "vault_generic_secret" "deployment_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/deployment_cidrs"
+}
+
 data "vault_generic_secret" "ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/db/ec2"
 }
 
 data "vault_generic_secret" "kms_keys" {
   path = "aws-accounts/${var.aws_account}/kms"
-}
-
-data "vault_generic_secret" "onprem_app_cidrs" {
-  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/onprem_app_cidrs"
 }
 
 data "vault_generic_secret" "security_kms_keys" {

--- a/groups/chips-db/locals.tf
+++ b/groups/chips-db/locals.tf
@@ -16,6 +16,7 @@ locals {
   ssm_data                = data.vault_generic_secret.ssm.data
   chs_subnet_data         = data.vault_generic_secret.chs_subnet.data
   onprem_app_cidrs        = jsondecode(data.vault_generic_secret.onprem_app_cidrs.data_json).cidrs
+  deployment_cidrs        = jsondecode(data.vault_generic_secret.deployment_cidrs.data_json).cidrs
 
   logs_kms_key_id        = local.kms_keys_data["logs"]
   ssm_logs_key_id        = local.kms_keys_data["ssm"]
@@ -30,7 +31,7 @@ locals {
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle)
-  ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh)
+  ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh, local.deployment_cidrs)
 
   iscsi_initiator_names = split(",", local.ec2_data["iscsi-initiator-names"])
 

--- a/groups/chips-rep-db/data.tf
+++ b/groups/chips-rep-db/data.tf
@@ -58,6 +58,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "deployment_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/deployment_cidrs"
+}
+
 data "vault_generic_secret" "ec2_data" {
   path = "applications/${var.aws_profile}/${var.application}/db/ec2"
 }

--- a/groups/chips-rep-db/locals.tf
+++ b/groups/chips-rep-db/locals.tf
@@ -19,6 +19,7 @@ locals {
   ssm_logs_key_id        = local.kms_keys_data["ssm"]
   chipsbackup_kms_key_id = local.kms_keys_data["chipsbackup"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
+  deployment_cidrs       = jsondecode(data.vault_generic_secret.deployment_cidrs.data_json).cidrs
 
   resources_bucket_name       = local.shared_services_s3_data["resources_bucket_name"]
   session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
@@ -27,7 +28,7 @@ locals {
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle)
-  ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh)
+  ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh, local.deployment_cidrs)
 
   iscsi_initiator_names = split(",", local.ec2_data["iscsi-initiator-names"])
 

--- a/groups/staffware-db/data.tf
+++ b/groups/staffware-db/data.tf
@@ -58,6 +58,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "deployment_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/deployment_cidrs"
+}
+
 data "vault_generic_secret" "ec2_data" {
   path = "applications/${var.aws_profile}/${var.application}/db/ec2"
 }

--- a/groups/staffware-db/locals.tf
+++ b/groups/staffware-db/locals.tf
@@ -19,6 +19,7 @@ locals {
   ssm_logs_key_id        = local.kms_keys_data["ssm"]
   chipsbackup_kms_key_id = local.kms_keys_data["chipsbackup"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
+  deployment_cidrs       = jsondecode(data.vault_generic_secret.deployment_cidrs.data_json).cidrs
 
   resources_bucket_name       = local.shared_services_s3_data["resources_bucket_name"]
   session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
@@ -27,7 +28,7 @@ locals {
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle)
-  ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh)
+  ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh, local.deployment_cidrs)
 
   iscsi_initiator_names = split(",", local.ec2_data["iscsi-initiator-names"])
 


### PR DESCRIPTION
Added data sources to obtain deployment CIDR ranges from Vault
Added local to extract CIDR list
Updated `ssh_allowed_ranges` to include the `deployment_cidrs`

Changes made for:
* chips-db
* chips-rep-db
* staffware-db