### PR TITLE
Add chips-db-batch group

### DIFF
--- a/groups/chips-db-batch/asg.tf
+++ b/groups/chips-db-batch/asg.tf
@@ -1,0 +1,109 @@
+# ------------------------------------------------------------------------------
+# CHIPS Security Group and rules
+# ------------------------------------------------------------------------------
+module "asg_security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.3"
+
+  name        = "sgr-${var.application}-asg-001"
+  description = "Security group for the ${var.application} asg"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  ingress_cidr_blocks = local.admin_cidrs
+  ingress_rules       = ["ssh-tcp"]
+
+  egress_rules = ["all-all"]
+}
+
+# ASG Module
+module "asg" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/terraform-aws-autoscaling?ref=tags/1.0.36"
+
+  count = var.asg_count
+
+  name = format("%s%s", var.application, count.index)
+
+  # Launch configuration
+  lc_name       = format("%s%s-launchconfig", var.application, count.index)
+  image_id      = data.aws_ami.ami.id
+  instance_type = var.instance_size
+  security_groups = [
+    module.asg_security_group.security_group_id,
+  ]
+  root_block_device = [
+    {
+      volume_size = var.instance_root_volume_size
+      volume_type = "gp2"
+      encrypted   = true
+      iops        = 0
+    },
+  ]
+  # Auto scaling group
+  asg_name                       = format("%s%s-asg", var.application, count.index)
+  vpc_zone_identifier            = data.aws_subnet_ids.application.ids
+  health_check_type              = "EC2"
+  min_size                       = var.asg_min_size
+  max_size                       = var.asg_max_size
+  desired_capacity               = var.asg_desired_capacity
+  health_check_grace_period      = 300
+  wait_for_capacity_timeout      = 0
+  force_delete                   = true
+  enable_instance_refresh        = var.enable_instance_refresh
+  refresh_min_healthy_percentage = 50
+  refresh_triggers               = ["launch_configuration"]
+  key_name                       = aws_key_pair.keypair.key_name
+  termination_policies           = ["OldestLaunchConfiguration"]
+  
+  iam_instance_profile = module.instance_profile.aws_iam_instance_profile.name
+  user_data_base64     = data.template_cloudinit_config.userdata_config.rendered
+
+  tags_as_map = merge(
+    local.default_tags,
+    tomap({
+      app-instance-name = format("%s%s", var.application, count.index)
+      config-base-path  = format("s3://%s/%s-configs/%s", var.config_bucket_name, var.application, var.environment)
+    })
+  )
+}
+
+resource "aws_cloudwatch_log_group" "log_groups" {
+  for_each = local.cloudwatch_logs
+
+  name              = each.value["log_group_name"]
+  retention_in_days = lookup(each.value, "log_group_retention", var.default_log_group_retention_in_days)
+  kms_key_id        = lookup(each.value, "kms_key_id", local.logs_kms_key_id)
+}
+
+#--------------------------------------------
+# ASG CloudWatch Alarms
+#--------------------------------------------
+module "asg_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/asg-cloudwatch-alarms?ref=tags/1.0.116"
+
+  count = var.asg_count
+
+  autoscaling_group_name = module.asg[count.index].this_autoscaling_group_name
+  prefix                 = "${var.aws_account}-${var.application}-${count.index}-asg-alarms"
+
+  in_service_evaluation_periods      = "1"
+  in_service_statistic_period        = "60"
+  expected_instances_in_service      = 1
+  in_pending_evaluation_periods      = "3"
+  in_pending_statistic_period        = "120"
+  in_standby_evaluation_periods      = "3"
+  in_standby_statistic_period        = "120"
+  in_terminating_evaluation_periods  = "3"
+  in_terminating_statistic_period    = "120"
+  total_instances_evaluation_periods = "1"
+  total_instances_statistic_period   = "120"
+  total_instances_in_service         = 1
+
+  actions_alarm = var.enable_sns_topic ? [module.cloudwatch_sns_email[0].sns_topic_arn, module.cloudwatch_sns_ooh[0].sns_topic_arn] : []
+  actions_ok    = var.enable_sns_topic ? [module.cloudwatch_sns_email[0].sns_topic_arn, module.cloudwatch_sns_ooh[0].sns_topic_arn] : []
+
+
+  depends_on = [
+    module.cloudwatch_sns_email,
+    module.asg
+  ]
+}

--- a/groups/chips-db-batch/data.tf
+++ b/groups/chips-db-batch/data.tf
@@ -1,0 +1,92 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "vpc" {
+  tags = {
+    Name = "vpc-${var.aws_account}"
+  }
+}
+
+data "aws_subnet_ids" "application" {
+  vpc_id = data.aws_vpc.vpc.id
+  filter {
+    name   = "tag:Name"
+    values = ["sub-application-*"]
+  }
+}
+
+data "aws_subnet" "application" {
+  for_each = data.aws_subnet_ids.application.ids
+  id       = each.value
+}
+
+data "aws_route53_zone" "private_zone" {
+  name         = local.internal_fqdn
+  private_zone = true
+}
+
+data "vault_generic_secret" "account_ids" {
+  path = "aws-accounts/account-ids"
+}
+
+data "vault_generic_secret" "internal_cidrs" {
+  path = "aws-accounts/network/internal_cidr_ranges"
+}
+
+data "vault_generic_secret" "ec2_data" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/ec2"
+}
+
+data "vault_generic_secret" "kms_keys" {
+  path = "aws-accounts/${var.aws_account}/kms"
+}
+
+data "vault_generic_secret" "security_kms_keys" {
+  path = "aws-accounts/security/kms"
+}
+
+data "vault_generic_secret" "security_s3_buckets" {
+  path = "aws-accounts/security/s3"
+}
+
+data "vault_generic_secret" "nfs_mounts" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
+}
+
+data "aws_ami" "ami" {
+  owners      = [data.vault_generic_secret.account_ids.data["development"]]
+  most_recent = var.ami_name == "docker-ami-*" ? true : false
+
+  filter {
+    name = "name"
+    values = [
+      var.ami_name,
+    ]
+  }
+
+  filter {
+    name = "state"
+    values = [
+      "available",
+    ]
+  }
+}
+
+data "template_file" "userdata" {
+  template = file("${path.module}/templates/user_data.tpl")
+  vars = {
+    ANSIBLE_INPUTS             = jsonencode(local.userdata_ansible_inputs)
+    DNS_DOMAIN                 = local.internal_fqdn
+    DNS_ZONE_ID                = data.aws_route53_zone.private_zone.zone_id
+    HERITAGE_ENVIRONMENT       = title(var.environment)
+  }
+}
+
+data "template_cloudinit_config" "userdata_config" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = data.template_file.userdata.rendered
+  }
+}

--- a/groups/chips-db-batch/iam.tf
+++ b/groups/chips-db-batch/iam.tf
@@ -1,0 +1,70 @@
+module "instance_profile" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/instance_profile?ref=tags/1.0.59"
+
+  name       = format("%s-profile", var.application)
+  enable_SSM = true
+
+  s3_buckets_write = [local.session_manager_bucket_name]
+
+  kms_key_refs = [
+    "alias/${var.account}/${var.region}/ebs",
+    local.ssm_kms_key_id
+  ]
+
+  cw_log_group_arns = length(local.log_groups) > 0 ? [format(
+    "arn:aws:logs:%s:%s:log-group:%s-*:*",
+    var.aws_region,
+    data.aws_caller_identity.current.account_id,
+    var.application
+  )] : null
+
+  custom_statements = [
+    {
+      sid    = "AllowAccessToConfigBucket",
+      effect = "Allow",
+      resources = [
+        "arn:aws:s3:::${var.config_bucket_name}/*",
+        "arn:aws:s3:::${var.config_bucket_name}"
+      ],
+      actions = [
+        "s3:Get*",
+        "s3:List*",
+      ]
+    },
+    {
+      sid       = "AllowReadOnlyAccessToECR",
+      effect    = "Allow",
+      resources = ["*"],
+      actions = [
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability"
+      ]
+    },
+    {
+      sid       = "AllowReadOnlyDescribeAccessToEC2",
+      effect    = "Allow",
+      resources = ["*"],
+      actions = [
+        "ec2:Describe*"
+      ]
+    },
+    {
+      sid       = "AllowWriteToRoute53",
+      effect    = "Allow",
+      resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.private_zone.zone_id}"],
+      actions = [
+        "route53:ChangeResourceRecordSets"
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/chips/*"],
+      actions = [
+        "ssm:GetParameter*"
+      ]
+    }
+  ]
+}

--- a/groups/chips-db-batch/keys.tf
+++ b/groups/chips-db-batch/keys.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "keypair" {
+  key_name   = var.application
+  public_key = local.ec2_data["public-key"]
+}

--- a/groups/chips-db-batch/locals.tf
+++ b/groups/chips-db-batch/locals.tf
@@ -1,0 +1,48 @@
+locals {
+
+  admin_cidrs              = values(data.vault_generic_secret.internal_cidrs.data)
+  application_subnet_cidrs = [for s in data.aws_subnet.application : s.cidr_block]
+  ec2_data                 = data.vault_generic_secret.ec2_data.data
+
+  internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
+
+  security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
+  kms_keys_data          = data.vault_generic_secret.kms_keys.data
+  logs_kms_key_id        = local.kms_keys_data["logs"]
+  ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
+  sns_kms_key_id         = local.kms_keys_data["sns"]
+
+  security_s3_data            = data.vault_generic_secret.security_s3_buckets.data
+  session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
+
+  nfs_mounts = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+
+  #For each log map passed, add an extra kv for the log group name and append the NFS directory into the filepath where required
+  log_directory_prefix = format("%s/%s", var.nfs_mount_destination_parent_dir, lookup(local.nfs_mounts["application_root"], "local_mount_point", ""))
+  cloudwatch_logs = {
+    for log, map in var.cloudwatch_logs :
+    log => merge(map, {
+      "log_group_name" = "${var.application}-${log}",
+      "file_path"      = replace(map["file_path"], "NFSPATH", "${local.log_directory_prefix}/APPINSTANCENAME")
+      }
+    )
+  }
+  # Extract the log group names for easier iteration
+  log_groups = compact([for log, map in local.cloudwatch_logs : lookup(map, "log_group_name", "")])
+
+  default_tags = {
+    Terraform       = "true"
+    Application     = upper(var.application)
+    ApplicationType = upper(var.application_type)
+    Region          = var.aws_region
+    Account         = var.aws_account
+  }
+
+  userdata_ansible_inputs = {
+    mounts_parent_dir          = var.nfs_mount_destination_parent_dir
+    mounts                     = local.nfs_mounts
+    install_watcher_service    = false
+    cw_log_files               = local.cloudwatch_logs
+    cw_agent_user              = "root"
+  }
+}

--- a/groups/chips-db-batch/main.tf
+++ b/groups/chips-db-batch/main.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_version = ">= 0.13.0, < 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 0.3, < 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 2.0.0"
+    }
+  }
+  backend "s3" {}
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "vault" {
+  auth_login {
+    path = "auth/userpass/login/${var.vault_username}"
+    parameters = {
+      password = var.vault_password
+    }
+  }
+}

--- a/groups/chips-db-batch/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-db-batch/profiles/heritage-development-eu-west-2/vars
@@ -1,0 +1,54 @@
+# Account details
+aws_profile = "heritage-development-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-development"
+
+# Account shorthand
+account = "hdev"
+region  = "euw2"
+
+# Application details
+application = "chips-db-batch"
+environment = "development"
+
+# ASG settings
+asg_count = 1
+instance_size = "t3.medium"
+enable_instance_refresh = true
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+}

--- a/groups/chips-db-batch/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-db-batch/profiles/heritage-live-eu-west-2/vars
@@ -1,0 +1,56 @@
+# Account details
+aws_profile = "heritage-live-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-live"
+
+# Account shorthand
+account = "hlive"
+region  = "euw2"
+
+# Application details
+application = "chips-db-batch"
+environment = "live"
+
+# ASG settings
+asg_count = 1
+instance_size = "t3.medium"
+
+# SNS Topic creation
+enable_sns_topic = true
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 180
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 180
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 180
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 180
+  }
+}

--- a/groups/chips-db-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db-batch/profiles/heritage-staging-eu-west-2/vars
@@ -1,0 +1,56 @@
+# Account details
+aws_profile = "heritage-staging-eu-west-2"
+aws_region  = "eu-west-2"
+aws_account = "heritage-staging"
+
+# Account shorthand
+account = "hstg"
+region  = "euw2"
+
+# Application details
+application = "chips-db-batch"
+environment = "staging"
+
+# ASG settings
+asg_count = 1
+instance_size = "t3.medium"
+
+# SNS Topic creation
+enable_sns_topic = true
+
+# NFS Mounts
+nfs_mount_destination_parent_dir = "/mnt/nfs"
+
+cloudwatch_logs = {
+  "audit.log" = {
+    file_path = "/var/log/audit"
+    log_group_retention = 7
+  }
+
+  "messages" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+  
+  "secure" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "yum.log" = {
+    file_path = "/var/log"
+    log_group_retention = 7
+  }
+
+  "ssm-errors" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "errors.log"
+    log_group_retention = 7
+  }
+
+  "ssm-agent" = {
+    file_path = "/var/log/amazon/ssm"
+    file_name = "amazon-ssm-agent.log"
+    log_group_retention = 7
+  }
+}

--- a/groups/chips-db-batch/sns.tf
+++ b/groups/chips-db-batch/sns.tf
@@ -1,0 +1,35 @@
+module "cloudwatch_sns_email" {
+  count = var.enable_sns_topic ? 1 : 0
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name              = "${var.application}-cloudwatch-emails"
+  display_name      = "${var.application}-cloudwatch-alarms-for-emails"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-CSI-Support"
+    )
+  )
+}
+
+module "cloudwatch_sns_ooh" {
+  count = var.enable_sns_topic ? 1 : 0
+
+  source  = "terraform-aws-modules/sns/aws"
+  version = "3.3.0"
+
+  name              = "${var.application}-cloudwatch-ooh-only"
+  display_name      = "${var.application}-cloudwatch-alarms-for-ooh"
+  kms_master_key_id = local.sns_kms_key_id
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-CSI-Support"
+    )
+  )
+}

--- a/groups/chips-db-batch/templates/user_data.tpl
+++ b/groups/chips-db-batch/templates/user_data.tpl
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Redirect the user-data output to the console logs
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+#Get application instance identifier from tags in AWS metadata service
+EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+EC2_REGION=$${AVAILABILITY_ZONE::-1}
+APP_INSTANCE_NAME=$( aws ec2 describe-tags --filters "Name=resource-id,Values=$EC2_INSTANCE_ID" "Name=key,Values=app-instance-name"  --region $EC2_REGION | jq -r '.Tags[]//[]|select(.Key=="app-instance-name")|.Value' )
+
+#Template application identifier into deployment playbook inputs
+echo '${ANSIBLE_INPUTS}' | jq --arg APP_INSTANCE_NAME "$APP_INSTANCE_NAME"  'walk(if type == "object" and has("file_path") then .file_path |= sub("APPINSTANCENAME"; $APP_INSTANCE_NAME) else . end)' > /root/ansible_inputs.json
+
+#Run Ansible playbook for server setup using provided inputs
+/usr/local/bin/ansible-playbook /root/deployment.yml -e '@/root/ansible_inputs.json'
+
+#Upsert a Route53 DNS record for this EC2 instance
+/usr/local/bin/update-dns.sh ${DNS_ZONE_ID} "$APP_INSTANCE_NAME.${DNS_DOMAIN}"
+
+#Run bootstrap script to download config from S3 and start Docker containers
+su -l ec2-user bootstrap

--- a/groups/chips-db-batch/variables.tf
+++ b/groups/chips-db-batch/variables.tf
@@ -1,0 +1,144 @@
+# ------------------------------------------------------------------------------
+# Vault Variables
+# ------------------------------------------------------------------------------
+variable "vault_username" {
+  type        = string
+  description = "Username for connecting to Vault - usually supplied through TF_VARS"
+}
+
+variable "vault_password" {
+  type        = string
+  description = "Password for connecting to Vault - usually supplied through TF_VARS"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables
+# ------------------------------------------------------------------------------
+variable "aws_region" {
+  type        = string
+  description = "The AWS region in which resources will be administered"
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "The AWS profile to use"
+}
+
+variable "aws_account" {
+  type        = string
+  description = "The name of the AWS Account in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# AWS Variables - Shorthand
+# ------------------------------------------------------------------------------
+
+variable "account" {
+  type        = string
+  description = "Short version of the name of the AWS Account in which resources will be administered"
+}
+
+variable "region" {
+  type        = string
+  description = "Short version of the name of the AWS region in which resources will be administered"
+}
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+variable "application" {
+  type        = string
+  description = "The component name of the application"
+}
+
+variable "environment" {
+  type        = string
+  description = "The name of the environment"
+}
+
+variable "application_type" {
+  type        = string
+  default     = "chips"
+  description = "The parent name of the application"
+}
+
+# ------------------------------------------------------------------------------
+# CHIPS ASG Variables
+# ------------------------------------------------------------------------------
+
+variable "instance_size" {
+  type        = string
+  description = "The size of the ec2 instances to build"
+}
+
+variable "asg_min_size" {
+  type        = number
+  default     = 1
+  description = "The min size of the ASG - always 1"
+}
+
+variable "asg_max_size" {
+  type        = number
+  default     = 1
+  description = "The max size of the ASG - always 1"
+}
+
+variable "asg_desired_capacity" {
+  type        = number
+  default     = 1
+  description = "The desired capacity of ASG - always 1"
+}
+
+variable "asg_count" {
+  type        = number
+  description = "The number of ASGs - typically 1 for dev and 2 for staging/live"
+}
+
+variable "ami_name" {
+  type        = string
+  default     = "docker-ami-*"
+  description = "Name of the AMI to use in the Auto Scaling configuration"
+}
+
+variable "instance_root_volume_size" {
+  type        = number
+  default     = 40
+  description = "Size of root volume attached to instances"
+}
+
+variable "enable_instance_refresh" {
+  type        = bool
+  default     = false
+  description = "Enable or disable instance refresh when the ASG is updated"
+}
+
+variable "nfs_mount_destination_parent_dir" {
+  type        = string
+  description = "The parent folder that all NFS shares should be mounted inside on the EC2 instance"
+  default     = "/mnt"
+}
+
+variable "default_log_group_retention_in_days" {
+  type        = number
+  default     = 14
+  description = "Total days to retain logs in CloudWatch log group if not specified for specific logs"
+}
+
+variable "cloudwatch_logs" {
+  type        = map(any)
+  description = "Map of log file information; used to create log groups, IAM permissions and passed to the application to configure remote logging"
+  default     = {}
+}
+
+variable "config_bucket_name" {
+  type        = string
+  description = "Bucket name the application will use to retrieve configuration files"
+  default     = "shared-services.eu-west-2.configs.ch.gov.uk"
+}
+
+variable "enable_sns_topic" {
+  type        = bool
+  description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
+  default     = false
+}

--- a/groups/chips-db-batch/version
+++ b/groups/chips-db-batch/version
@@ -1,0 +1,1 @@
+chips-db-batch-0.1


### PR DESCRIPTION
Adds a new group to create a chips-db-batch instance (using an ASG for resilience).  This is to be used to run oltp, rep & fes batch docker containers.

Resolves: https://companieshouse.atlassian.net/browse/CM-1435