### PR TITLE
Add autoscaling describe permission

### DIFF
--- a/groups/staffware-app/iam.tf
+++ b/groups/staffware-app/iam.tf
@@ -52,6 +52,14 @@ module "iprocess_app_profile" {
       actions = [
         "cloudwatch:PutMetricData"
       ]
+    },
+    {
+      sid       = "AllowAutoscalingDescribe"
+      effect    = "Allow"
+      resources = ["*"]
+      actions = [
+        "autoscaling:Describe*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adding permission to allow use of ASG name tag in CM-1414 cloudwatch
config