### PR TITLE
Changing to EC2 describe permission

### DIFF
--- a/groups/staffware-app/iam.tf
+++ b/groups/staffware-app/iam.tf
@@ -54,11 +54,11 @@ module "iprocess_app_profile" {
       ]
     },
     {
-      sid       = "AllowAutoscalingDescribe"
+      sid       = "AllowEC2Describe"
       effect    = "Allow"
       resources = ["*"]
       actions = [
-        "autoscaling:Describe*"
+        "ec2:Describe*"
       ]
     }
   ]


### PR DESCRIPTION
Adding permission to allow use of ASG name tag in CM-1414 cloudwatch
config