### PR TITLE
Add Standardised Oracle DB CloudWatch Alarms

### DIFF
--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -222,3 +222,15 @@ resource "aws_cloudwatch_log_group" "cloudwatch_oracle_log_groups" {
     })
   )
 }
+
+module "oracledb_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
+
+  db_instance_id         = "chips-oltp-db"
+  db_instance_shortname  = var.db_instance_shortname
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alert_log_group_name   = "chips-oltp-db/oracle/alert"
+  alarm_name_prefix      = "EC2"
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/chips-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-live-eu-west-2/vars
@@ -105,3 +105,9 @@ chips_db_sg = [
   "sgr-chips-uam-ec2-001-*",
   "sgr-gfn-app-001-*"
 ]
+
+## Oracle DB CloudWatch Alarms
+db_instance_shortname  = "ENVP1"
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -104,3 +104,9 @@ chips_db_sg = [
   "sgr-chips-users-rest-asg-001-*",
   "sgr-chips-uam-ec2-001-*"
 ]
+
+## Oracle DB CloudWatch Alarms
+db_instance_shortname  = "ENVT14"
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -274,3 +274,27 @@ variable "chips_db_sg" {
   description = "List of CHIPS DB Security Groups"
   default     = []
 }
+
+
+# ------------------------------------------------------------------------------
+# DB CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = bool
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}
+
+variable "db_instance_shortname" {
+  type        = string
+  description = "The shortname or SID for the Oracle DB instance"
+}

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -199,3 +199,15 @@ resource "aws_cloudwatch_log_group" "cloudwatch_oracle_log_groups" {
     })
   )
 }
+
+module "oracledb_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
+
+  db_instance_id         = "chips-rep-db"
+  db_instance_shortname  = var.db_instance_shortname
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alert_log_group_name   = "chips-rep-db/oracle/alert"
+  alarm_name_prefix      = "EC2"
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
@@ -106,3 +106,9 @@ chips_rep_db_sg = [
   "sgr-windows-workloads-bus-obj-1-server-*",
   "sgr-gfn-app-001-*"
 ]
+
+## Oracle DB CloudWatch Alarms
+db_instance_shortname  = "ENVP1REP"
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -107,5 +107,8 @@ chips_rep_db_sg = [
 ]
 
 
-
-
+## Oracle DB CloudWatch Alarms
+db_instance_shortname  = "ENVT14RP"
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -273,3 +273,26 @@ variable "chips_rep_db_sg" {
   description = "List of CHIPS DB REP Security Groups"
   default     = []
 }
+
+# ------------------------------------------------------------------------------
+# DB CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = bool
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}
+
+variable "db_instance_shortname" {
+  type        = string
+  description = "The shortname or SID for the Oracle DB instance"
+}

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -198,3 +198,15 @@ resource "aws_cloudwatch_log_group" "cloudwatch_oracle_log_groups" {
     })
   )
 }
+
+module "oracledb_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
+
+  db_instance_id         = "staffware-db"
+  db_instance_shortname  = var.db_instance_shortname
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alert_log_group_name   = "staffware-db/oracle/alert"
+  alarm_name_prefix      = "EC2"
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/staffware-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-live-eu-west-2/vars
@@ -89,3 +89,9 @@ staffware_db_sg = [
   "sgr-chips-oltp-db-ec2-001-*",
   "sgr-chips-rep-db-ec2-001-*"
 ]
+
+## Oracle DB CloudWatch Alarms
+db_instance_shortname  = "STAFLIVE"
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -89,3 +89,9 @@ staffware_db_sg = [
   "sgr-chips-oltp-db-ec2-001-*",
   "sgr-chips-rep-db-ec2-001-*"
 ]
+
+## Oracle DB CloudWatch Alarms
+db_instance_shortname  = "STAFFSTG"
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -243,3 +243,26 @@ variable "staffware_db_sg" {
   description = "List of Staffware DB Security Groups"
   default     = []
 }
+
+# ------------------------------------------------------------------------------
+# DB CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = bool
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}
+
+variable "db_instance_shortname" {
+  type        = string
+  description = "The shortname or SID for the Oracle DB instance"
+}


### PR DESCRIPTION
Added module config to deploy CloudWatch log filters and alarms for `chips-db`, `chips-rep-db` and `staffware-db`
Added supporting variables
Populated profile vars to match deployments

Alarm actions are currently disabled to prevent notification spam while they settle

Partially Resolves: CM-1427