### PR TITLE
Update Oracle Alarms

### DIFF
--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -230,7 +230,7 @@ module "oracledb_cloudwatch_alarms" {
   db_instance_shortname  = var.db_instance_shortname
   alarm_actions_enabled  = var.alarm_actions_enabled
   alert_log_group_name   = "chips-oltp-db/oracle/alert"
-  alarm_name_prefix      = "EC2"
+  alarm_name_prefix      = "Oracle EC2"
   alarm_topic_name       = var.alarm_topic_name
   alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }

--- a/groups/chips-rds/rds.tf
+++ b/groups/chips-rds/rds.tf
@@ -134,11 +134,12 @@ module "chips_rds" {
 }
 
 module "rds_cloudwatch_alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
 
-  rds_instance_id        = module.chips_rds.this_db_instance_id
-  rds_instance_shortname = upper(var.name)
+  db_instance_id         = module.chips_rds.this_db_instance_id
+  db_instance_shortname  = upper(var.name)
   alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_name_prefix      = "Oracle RDS"
   alarm_topic_name       = var.alarm_topic_name
   alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -207,7 +207,7 @@ module "oracledb_cloudwatch_alarms" {
   db_instance_shortname  = var.db_instance_shortname
   alarm_actions_enabled  = var.alarm_actions_enabled
   alert_log_group_name   = "chips-rep-db/oracle/alert"
-  alarm_name_prefix      = "EC2"
+  alarm_name_prefix      = "Oracle EC2"
   alarm_topic_name       = var.alarm_topic_name
   alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -206,7 +206,7 @@ module "oracledb_cloudwatch_alarms" {
   db_instance_shortname  = var.db_instance_shortname
   alarm_actions_enabled  = var.alarm_actions_enabled
   alert_log_group_name   = "staffware-db/oracle/alert"
-  alarm_name_prefix      = "EC2"
+  alarm_name_prefix      = "Oracle EC2"
   alarm_topic_name       = var.alarm_topic_name
   alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }


### PR DESCRIPTION
Updated existing RDS alarms module to use updated terraform module path and version
Updated variable names to match updated module requirements
Set `alarm_name_prefix` appropriately