### PR TITLE
Allow BCD RDS to access CHIPS OLTP

### DIFF
--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -102,7 +102,8 @@ chips_db_sg = [
   "sgr-staffware-db-ec2-001-*",
   "sgr-chips-ef-batch-asg-001-*",
   "sgr-chips-users-rest-asg-001-*",
-  "sgr-chips-uam-ec2-001-*"
+  "sgr-chips-uam-ec2-001-*",
+  "sgr-bcd-rds-*"
 ]
 
 ## Oracle DB CloudWatch Alarms


### PR DESCRIPTION
Updated vars to add BCD RDS security group pattern to permit acecss to CHIPS OLTP

Resolves: INC0356915