### PR TITLE
Reference 1.0.175 of chips-app terraform module

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.169"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.175"
 
   application                      = var.application
   application_type                 = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.169"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.175"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.169"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.175"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.169"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.175"
 
   application                      = var.application
   application_type                 = "chips"


### PR DESCRIPTION
This brings in a change to allow access for http/https to the CHIPS ALBs from the CIDRs defined in vault at /applications/<account>-<region>/chips/client_cidrs

Resolves:
https://companieshouse.atlassian.net/browse/CM-1374
