### PR TITLE
Allow access to oltp, rep & staffware DBs from chips-db-batch

### DIFF
--- a/groups/chips-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-live-eu-west-2/vars
@@ -102,6 +102,7 @@ chips_db_sg = [
   "sgr-staffware-db-ec2-001-*",
   "sgr-chips-ef-batch-asg-001-*",
   "sgr-chips-users-rest-asg-001-*",
+  "sgr-chips-db-batch-asg-001-*",
   "sgr-chips-uam-ec2-001-*",
   "sgr-gfn-app-001-*",
   "sgr-ewf-rds-001-*",

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -102,6 +102,7 @@ chips_db_sg = [
   "sgr-staffware-db-ec2-001-*",
   "sgr-chips-ef-batch-asg-001-*",
   "sgr-chips-users-rest-asg-001-*",
+  "sgr-chips-db-batch-asg-001-*",  
   "sgr-chips-uam-ec2-001-*",
   "sgr-bcd-rds-001-*",
   "sgr-ewf-rds-001-*"

--- a/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
@@ -103,6 +103,7 @@ chips_rep_db_sg = [
   "sgr-chips-ef-batch-asg-001-*",
   "sgr-chips-users-rest-asg-001-*",
   "sgr-chips-read-only-asg-001-*",
+  "sgr-chips-db-batch-asg-001-*",
   "sgr-windows-workloads-bus-obj-1-server-*",
   "sgr-gfn-app-001-*"
 ]

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -103,6 +103,7 @@ chips_rep_db_sg = [
   "sgr-chips-ef-batch-asg-001-*",
   "sgr-chips-users-rest-asg-001-*",
   "sgr-chips-read-only-asg-001-*",
+  "sgr-chips-db-batch-asg-001-*",
   "sgr-windows-workloads-bus-obj-2-server-*"
 ]
 

--- a/groups/staffware-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-live-eu-west-2/vars
@@ -86,6 +86,7 @@ staffware_db_sg = [
   "sgr-iprocess-app-asg-*",
   "sgr-chips-users-rest-asg-*",
   "sgr-chips-ef-batch-asg-*",
+  "sgr-chips-db-batch-asg-001-*",  
   "sgr-chips-oltp-db-ec2-001-*",
   "sgr-chips-rep-db-ec2-001-*",
   "sgr-gfn-app-001-*",

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -86,6 +86,7 @@ staffware_db_sg = [
   "sgr-iprocess-app-asg-*",
   "sgr-chips-users-rest-asg-*",
   "sgr-chips-ef-batch-asg-*",
+  "sgr-chips-db-batch-asg-001-*",
   "sgr-chips-oltp-db-ec2-001-*",
   "sgr-chips-rep-db-ec2-001-*"
 ]


### PR DESCRIPTION
Allow connections to the CHIPS OLTP, REP & Staffware Oracle databases from the chips-db-batch EC2 instance.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1436
https://companieshouse.atlassian.net/browse/CM-1437