### PR TITLE
Use 1.0.179 of chips-app module & set higher thresholds for users-rest

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.176"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
 
   application                      = var.application
   application_type                 = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.176"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.176"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.176"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
 
   application                      = var.application
   application_type                 = "chips"
@@ -47,6 +47,8 @@ module "chips-users-rest" {
   alb_idle_timeout                 = 180
   enable_sns_topic                 = var.enable_sns_topic
   create_nlb                       = true
+  maximum_5xx_threshold            = 5
+  maximum_4xx_threshold            = 5
 
   additional_ingress_with_cidr_blocks = [
     {


### PR DESCRIPTION
Set 4xx & 5xx thresholds to 5 (instead of 2) for chips-user-rest clusters by using new chips-app module version.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1473