### PR TITLE
Implement AWS Backup Tags for DB EC2 Instances

### DIFF
--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -97,6 +97,7 @@ resource "aws_instance" "db_ec2" {
   tags = merge(
     local.default_tags,
     tomap({
+      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1)
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -17,6 +17,8 @@ db_instance_size = "r5.16xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
+backup_plan_tag = "backup14"
+
 # NFS Mounts
 nfs_server = "192.168.255.19"
 nfs_mount_destination_parent_dir = "/-"

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -135,6 +135,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "backup_plan_tag" {
+  type        = string
+  description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
+  default     = "backup21"
+}
+
 # ------------------------------------------------------------------------------
 # NFS Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -75,6 +75,7 @@ resource "aws_instance" "db_ec2" {
   tags = merge(
     local.default_tags,
     tomap({
+      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1),
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -17,6 +17,8 @@ db_instance_size = "r5.12xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
+backup_plan_tag = "backup14"
+
 # NFS Mounts
 nfs_server = "192.168.255.19"
 nfs_mount_destination_parent_dir = "/-"

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -165,6 +165,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "backup_plan_tag" {
+  type        = string
+  description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
+  default     = "backup21"
+}
+
 # ------------------------------------------------------------------------------
 # Ansible SSM variables
 # ------------------------------------------------------------------------------

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -74,6 +74,7 @@ resource "aws_instance" "db_ec2" {
   tags = merge(
     local.default_tags,
     tomap({
+      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1),
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -18,6 +18,8 @@ ami_id = "ami-07753d6b2935e32bf"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
+backup_plan_tag = "backup14"
+
 cloudwatch_namespace = "CHIPS/STFWARE"
 
 ############################################

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -135,6 +135,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "backup_plan_tag" {
+  type        = string
+  description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
+  default     = "backup21"
+}
+
 # ------------------------------------------------------------------------------
 # Ansible SSM variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added `Backup` resource tag to DB EC2 instances
Added variable to allow the tag value to be specified, according to the backup selection rules, with a default corresponding to 21 days backup retention
Set variable to the 14-day retnetion value in Staging

Resolves: CM-1479