### PR TITLE
Allow DBLink to Chips REP

### DIFF
--- a/groups/chips-rep-db/data.tf
+++ b/groups/chips-rep-db/data.tf
@@ -66,6 +66,10 @@ data "vault_generic_secret" "additional_app_cidrs" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/additional_app_cidrs"
 }
 
+data "vault_generic_secret" "dblink_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/dblink_cidrs"
+}
+
 data "vault_generic_secret" "ec2_data" {
   path = "applications/${var.aws_profile}/${var.application}/db/ec2"
 }

--- a/groups/chips-rep-db/locals.tf
+++ b/groups/chips-rep-db/locals.tf
@@ -21,6 +21,7 @@ locals {
   chipsbackup_kms_key_id = local.kms_keys_data["chipsbackup"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
   deployment_cidrs       = jsondecode(data.vault_generic_secret.deployment_cidrs.data_json).cidrs
+  dblink_cidrs           = jsondecode(data.vault_generic_secret.dblink_cidrs.data_json).cidrs
 
   resources_bucket_name       = local.shared_services_s3_data["resources_bucket_name"]
   session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
@@ -28,7 +29,7 @@ locals {
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
-  oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle, local.additional_app_cidrs)
+  oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle, local.additional_app_cidrs, local.dblink_cidrs)
   ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh, local.deployment_cidrs)
 
   iscsi_initiator_names = split(",", local.ec2_data["iscsi-initiator-names"])


### PR DESCRIPTION
Added vault data lookup and local var for non-VPC CIDRs requiring Oracle access for DBLink
Updated `oracle_allowed_ranges` local to include the DBLink CIDRs

Resolves: INC0358786