### PR TITLE
Add AWS Backup tags to Staging DB Instances

### DIFF
--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -97,6 +97,7 @@ resource "aws_instance" "db_ec2" {
   tags = merge(
     local.default_tags,
     tomap({
+      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1)
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -96,8 +96,8 @@ resource "aws_instance" "db_ec2" {
 
   tags = merge(
     local.default_tags,
+    local.aws_backup_plan_tags,
     tomap({
-      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1)
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/chips-db/locals.tf
+++ b/groups/chips-db/locals.tf
@@ -104,6 +104,10 @@ locals {
     Account     = var.aws_account
   }
 
+  aws_backup_plan_tags = var.aws_backup_plan_enable ? {
+    Backup      = var.aws_backup_plan_tag
+  } : {}
+
   failover_approvers = distinct(compact(flatten([for roles in data.aws_iam_roles.failover_approvers : roles.arns])))
 
   source_security_group_id = [for item in data.aws_security_group.chips_sg : item.id]

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -17,6 +17,8 @@ db_instance_size = "r5.16xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
+backup_plan_tag = "backup14"
+
 # NFS Mounts
 nfs_server = "192.168.255.19"
 nfs_mount_destination_parent_dir = "/-"

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -17,7 +17,8 @@ db_instance_size = "r5.16xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
-backup_plan_tag = "backup14"
+aws_backup_plan_enable = true
+aws_backup_plan_tag = "backup14"
 
 # NFS Mounts
 nfs_server = "192.168.255.19"

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -135,7 +135,13 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
-variable "backup_plan_tag" {
+variable "aws_backup_plan_enable" {
+  type        = bool
+  description = "Controls whether the EC2 instances should be covered by an AWS Backup plan (true) or omitted (false)"
+  default     = false
+}
+
+variable "aws_backup_plan_tag" {
   type        = string
   description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
   default     = "backup21"

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -135,6 +135,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "backup_plan_tag" {
+  type        = string
+  description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
+  default     = "backup21"
+}
+
 # ------------------------------------------------------------------------------
 # NFS Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -74,8 +74,8 @@ resource "aws_instance" "db_ec2" {
 
   tags = merge(
     local.default_tags,
+    local.aws_backup_plan_tags,
     tomap({
-      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1),
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -75,6 +75,7 @@ resource "aws_instance" "db_ec2" {
   tags = merge(
     local.default_tags,
     tomap({
+      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1),
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/chips-rep-db/locals.tf
+++ b/groups/chips-rep-db/locals.tf
@@ -101,6 +101,10 @@ locals {
     Account     = var.aws_account
   }
 
+  aws_backup_plan_tags = var.aws_backup_plan_enable ? {
+    Backup      = var.aws_backup_plan_tag
+  } : {}
+
   failover_approvers = distinct(compact(flatten([for roles in data.aws_iam_roles.failover_approvers : roles.arns])))
 
   source_security_group_id = [for item in data.aws_security_group.chips_rep_sg : item.id]

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -17,6 +17,8 @@ db_instance_size = "r5.12xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
+backup_plan_tag = "backup14"
+
 # NFS Mounts
 nfs_server = "192.168.255.19"
 nfs_mount_destination_parent_dir = "/-"

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -17,7 +17,8 @@ db_instance_size = "r5.12xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
-backup_plan_tag = "backup14"
+aws_backup_plan_enable = true
+aws_backup_plan_tag = "backup14"
 
 # NFS Mounts
 nfs_server = "192.168.255.19"

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -165,7 +165,13 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
-variable "backup_plan_tag" {
+variable "aws_backup_plan_enable" {
+  type        = bool
+  description = "Controls whether the EC2 instances should be covered by an AWS Backup plan (true) or omitted (false)"
+  default     = false
+}
+
+variable "aws_backup_plan_tag" {
   type        = string
   description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
   default     = "backup21"

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -165,6 +165,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "backup_plan_tag" {
+  type        = string
+  description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
+  default     = "backup21"
+}
+
 # ------------------------------------------------------------------------------
 # Ansible SSM variables
 # ------------------------------------------------------------------------------

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -73,8 +73,8 @@ resource "aws_instance" "db_ec2" {
 
   tags = merge(
     local.default_tags,
+    local.aws_backup_plan_tags,
     tomap({
-      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1),
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -74,6 +74,7 @@ resource "aws_instance" "db_ec2" {
   tags = merge(
     local.default_tags,
     tomap({
+      "Backup"      = var.backup_plan_tag,
       "Name"        = format("%s-db-%02d", var.application, count.index + 1),
       "Domain"      = local.internal_fqdn,
       "UNQNAME"     = var.oracle_unqname,

--- a/groups/staffware-db/locals.tf
+++ b/groups/staffware-db/locals.tf
@@ -97,6 +97,11 @@ locals {
     Account     = var.aws_account
   }
 
+  aws_backup_plan_tags = var.aws_backup_plan_enable ? {
+    Backup      = var.aws_backup_plan_tag
+  } : {}
+
+
   failover_approvers = distinct(compact(flatten([for roles in data.aws_iam_roles.failover_approvers : roles.arns])))
 
   source_security_group_id = [for item in data.aws_security_group.staffware_sg : item.id]

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -18,7 +18,8 @@ ami_id = "ami-07753d6b2935e32bf"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
-backup_plan_tag = "backup14"
+aws_backup_plan_enable = true
+aws_backup_plan_tag = "backup14"
 
 cloudwatch_namespace = "CHIPS/STFWARE"
 

--- a/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/staffware-db/profiles/heritage-staging-eu-west-2/vars
@@ -18,6 +18,8 @@ ami_id = "ami-07753d6b2935e32bf"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 
+backup_plan_tag = "backup14"
+
 cloudwatch_namespace = "CHIPS/STFWARE"
 
 ############################################

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -135,7 +135,13 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
-variable "backup_plan_tag" {
+variable "aws_backup_plan_enable" {
+  type        = bool
+  description = "Controls whether the EC2 instances should be covered by an AWS Backup plan (true) or omitted (false)"
+  default     = false
+}
+
+variable "aws_backup_plan_tag" {
   type        = string
   description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
   default     = "backup21"

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -135,6 +135,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "backup_plan_tag" {
+  type        = string
+  description = "The tag value to control which AWS Backup plan is used. One of [true, backup14, backup21] for daily backups with 7, 14 or 21 days retention respectively"
+  default     = "backup21"
+}
+
 # ------------------------------------------------------------------------------
 # Ansible SSM variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added vars to control whether EC2 instances are included in an AWS Backup plan
Added local to define the required instance tag and value
Updated EC2 instance resource to include the local in the tag map
Added Staging vars to enable the plan tag

Resolves: CM-1479