### PR TITLE
Correct chipsdomain.log filename in all profiles

### DIFF
--- a/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-development-eu-west-2/vars
@@ -166,7 +166,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 

--- a/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
@@ -168,7 +168,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 

--- a/groups/chips-read-only/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-development-eu-west-2/vars
@@ -166,7 +166,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 }

--- a/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
@@ -168,7 +168,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 180
   }
 }

--- a/groups/chips-read-only/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-staging-eu-west-2/vars
@@ -168,7 +168,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 }

--- a/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-development-eu-west-2/vars
@@ -112,7 +112,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 }

--- a/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
@@ -114,7 +114,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 }

--- a/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
@@ -166,7 +166,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 

--- a/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
@@ -168,7 +168,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 180
   }
 

--- a/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
@@ -168,7 +168,7 @@ cloudwatch_logs = {
 
   "wladmin-chipsdomain" = {
     file_path = "NFSPATH/running-servers/wladmin/logs"
-    file_name = "chipsdomain.out"
+    file_name = "chipsdomain.log"
     log_group_retention = 7
   }
 


### PR DESCRIPTION
Part of tidy-up work for CM-1467 - ensuring logs are ingested by Cloudwatch as reducing retention time on server.