### PR TITLE
changing logical-standby size to r5.12xlarge

### DIFF
--- a/groups/oltp-logical-standby/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/oltp-logical-standby/profiles/heritage-staging-eu-west-2/vars
@@ -13,7 +13,7 @@ oracle_unqname = "cdb1"
 oracle_sid = "ENVT14"
 
 db_instance_count = 1
-db_instance_size = "r5.16xlarge"
+db_instance_size = "r5.12xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 


### PR DESCRIPTION
changing logical-standby size to r5.12xlarge - This will make the instance smaller and is based on the other Chips reporting box