### PR TITLE
Allow ingress from chips-control to chips instances

### DIFF
--- a/groups/chips-db-batch/asg.tf
+++ b/groups/chips-db-batch/asg.tf
@@ -12,6 +12,16 @@ module "asg_security_group" {
   ingress_cidr_blocks = local.admin_cidrs
   ingress_rules       = ["ssh-tcp"]
 
+  ingress_with_source_security_group_id = [
+    {
+      from_port                = 22
+      to_port                  = 22
+      protocol                 = "tcp"
+      description              = "${var.application} SSH from chips-control"
+      source_security_group_id = data.aws_security_group.chips_control.id
+    }
+  ]
+
   egress_rules = ["all-all"]
 }
 

--- a/groups/chips-db-batch/data.tf
+++ b/groups/chips-db-batch/data.tf
@@ -19,6 +19,13 @@ data "aws_subnet" "application" {
   id       = each.value
 }
 
+data "aws_security_group" "chips_control" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-control-asg-001-*"]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
 
   application                      = var.application
   application_type                 = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.179"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
 
   application                      = var.application
   application_type                 = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.181"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
 
   application                      = var.application
   application_type                 = "chips"


### PR DESCRIPTION
Reference 1.0.182 of chips-app module to allow SSH access from chips-control to chips-users-rest, chips-ef-batch,
chips-read-only and chips-tux-proxy EC2 instances.
Also allow SSH access from chips-control to chips-db-batch instance by adding security group ingress rule.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1493