### PR TITLE
Ingest fes batch logs [CM-1438]

### DIFF
--- a/groups/chips-db-batch/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-db-batch/profiles/heritage-live-eu-west-2/vars
@@ -57,5 +57,29 @@ cloudwatch_logs = {
   "ch_support_alert.log" = {
     file_path = "NFSPATH/running-servers/ch-support"
     log_group_retention = 180
-  }      
+  }
+
+  "fes-out.log" = {
+    file_path = "NFSPATH/running-servers/fes-out"
+    file_name = "*.log"
+    log_group_retention = 180
+  }
+
+  "dps-out.log" = {
+    file_path = "NFSPATH/running-servers/dps-out"
+    file_name = "*.log"
+    log_group_retention = 180
+  }
+
+  "fes-file-loader.log" = {
+    file_path = "NFSPATH/running-servers/fes-file-loader"
+    file_name = "*.log"
+    log_group_retention = 180
+  }
+
+  "move-scan-files.log" = {
+    file_path = "NFSPATH/running-servers/move-scan-files"
+    file_name = "*.log"
+    log_group_retention = 180
+  }
 }

--- a/groups/chips-db-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db-batch/profiles/heritage-staging-eu-west-2/vars
@@ -56,18 +56,30 @@ cloudwatch_logs = {
 
   "ch_support_alert.log" = {
     file_path = "NFSPATH/running-servers/ch-support"
-    log_group_retention = 180
-  }    
+    log_group_retention = 7
+  }
 
   "fes-out.log" = {
     file_path = "NFSPATH/running-servers/fes-out"
     file_name = "*.log"
-    log_group_retention = 180
+    log_group_retention = 7
   }
 
   "dps-out.log" = {
     file_path = "NFSPATH/running-servers/dps-out"
     file_name = "*.log"
-    log_group_retention = 180
-  } 
+    log_group_retention = 7
+  }
+
+  "fes-file-loader.log" = {
+    file_path = "NFSPATH/running-servers/fes-file-loader"
+    file_name = "*.log"
+    log_group_retention = 7
+  }
+
+  "move-scan-files.log" = {
+    file_path = "NFSPATH/running-servers/move-scan-files"
+    file_name = "*.log"
+    log_group_retention = 7
+  }
 }


### PR DESCRIPTION
Adding log groups for move-scan-files and fes-file-loader scripts. Only ingesting system script logs, not housekeeping/monitoring/reporting.

Also adjusting retention of existing staging logs to be consistently 7d, and adding fes-out & dps-out definitions to live.