### PR TITLE
Allow SSH access from sgr-gfn-app-001-* in Live

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,24 +28,25 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.183"
 
-  application                      = var.application
-  application_type                 = var.application_type
-  aws_region                       = var.aws_region
-  aws_account                      = var.aws_account
-  account                          = var.account
-  region                           = var.region
-  environment                      = var.environment
-  asg_count                        = var.asg_count
-  instance_size                    = var.instance_size
-  enable_instance_refresh          = var.enable_instance_refresh
-  nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
-  cloudwatch_logs                  = var.cloudwatch_logs
-  config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
-  alb_idle_timeout                 = 180
-  enable_sns_topic                 = var.enable_sns_topic
+  application                        = var.application
+  application_type                   = var.application_type
+  aws_region                         = var.aws_region
+  aws_account                        = var.aws_account
+  account                            = var.account
+  region                             = var.region
+  environment                        = var.environment
+  asg_count                          = var.asg_count
+  instance_size                      = var.instance_size
+  enable_instance_refresh            = var.enable_instance_refresh
+  nfs_mount_destination_parent_dir   = var.nfs_mount_destination_parent_dir
+  nfs_mounts                         = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+  cloudwatch_logs                    = var.cloudwatch_logs
+  config_bucket_name                 = "shared-services.eu-west-2.configs.ch.gov.uk"
+  alb_idle_timeout                   = 180
+  enable_sns_topic                   = var.enable_sns_topic
+  ssh_access_security_group_patterns = var.ssh_access_security_group_patterns
 
   additional_ingress_with_cidr_blocks = [
     {

--- a/groups/chips-ef-batch/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-live-eu-west-2/vars
@@ -18,6 +18,12 @@ instance_size = "z1d.xlarge"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Security Groups with SSH access
+ssh_access_security_group_patterns = [
+  "sgr-chips-control-asg-001-*",
+  "sgr-gfn-app-001-*"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-ef-batch/variables.tf
+++ b/groups/chips-ef-batch/variables.tf
@@ -119,6 +119,12 @@ variable "enable_instance_refresh" {
   description = "Enable or disable instance refresh when the ASG is updated"
 }
 
+variable "ssh_access_security_group_patterns" {
+  type        = list(string)
+  description = "List of source security group name patterns that will have SSH access"
+  default     = ["sgr-chips-control-asg-001-*"]
+}
+
 # ------------------------------------------------------------------------------
 # CHIPS ALB Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,25 +28,26 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.183"
 
-  application                      = var.application
-  application_type                 = "chips"
-  aws_region                       = var.aws_region
-  aws_account                      = var.aws_account
-  account                          = var.account
-  region                           = var.region
-  environment                      = var.environment
-  asg_count                        = var.asg_count
-  instance_size                    = var.instance_size
-  enable_instance_refresh          = var.enable_instance_refresh
-  nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
-  cloudwatch_logs                  = var.cloudwatch_logs
-  config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
-  alb_idle_timeout                 = 180
-  enable_sns_topic                 = var.enable_sns_topic
-  create_app_target_group          = false
+  application                        = var.application
+  application_type                   = "chips"
+  aws_region                         = var.aws_region
+  aws_account                        = var.aws_account
+  account                            = var.account
+  region                             = var.region
+  environment                        = var.environment
+  asg_count                          = var.asg_count
+  instance_size                      = var.instance_size
+  enable_instance_refresh            = var.enable_instance_refresh
+  nfs_mount_destination_parent_dir   = var.nfs_mount_destination_parent_dir
+  nfs_mounts                         = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+  cloudwatch_logs                    = var.cloudwatch_logs
+  config_bucket_name                 = "shared-services.eu-west-2.configs.ch.gov.uk"
+  alb_idle_timeout                   = 180
+  enable_sns_topic                   = var.enable_sns_topic
+  create_app_target_group            = false
+  ssh_access_security_group_patterns = var.ssh_access_security_group_patterns
 
   additional_ingress_with_cidr_blocks = [
     {

--- a/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-read-only/profiles/heritage-live-eu-west-2/vars
@@ -18,6 +18,12 @@ instance_size = "t3.large"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Security Groups with SSH access
+ssh_access_security_group_patterns = [
+  "sgr-chips-control-asg-001-*",
+  "sgr-gfn-app-001-*"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-read-only/variables.tf
+++ b/groups/chips-read-only/variables.tf
@@ -83,6 +83,12 @@ variable "enable_instance_refresh" {
   description = "Enable or disable instance refresh when the ASG is updated"
 }
 
+variable "ssh_access_security_group_patterns" {
+  type        = list(string)
+  description = "List of source security group name patterns that will have SSH access"
+  default     = ["sgr-chips-control-asg-001-*"]
+}
+
 # ------------------------------------------------------------------------------
 # NFS Mount Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,25 +28,26 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.183"
 
-  application                      = var.application
-  application_type                 = "chips"
-  aws_region                       = var.aws_region
-  aws_account                      = var.aws_account
-  account                          = var.account
-  region                           = var.region
-  environment                      = var.environment
-  asg_count                        = var.asg_count
-  instance_size                    = var.instance_size
-  enable_instance_refresh          = var.enable_instance_refresh
-  nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
-  cloudwatch_logs                  = var.cloudwatch_logs
-  config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
-  alb_idle_timeout                 = 180
-  enable_sns_topic                 = var.enable_sns_topic
-  create_app_target_group          = false
+  application                        = var.application
+  application_type                   = "chips"
+  aws_region                         = var.aws_region
+  aws_account                        = var.aws_account
+  account                            = var.account
+  region                             = var.region
+  environment                        = var.environment
+  asg_count                          = var.asg_count
+  instance_size                      = var.instance_size
+  enable_instance_refresh            = var.enable_instance_refresh
+  nfs_mount_destination_parent_dir   = var.nfs_mount_destination_parent_dir
+  nfs_mounts                         = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+  cloudwatch_logs                    = var.cloudwatch_logs
+  config_bucket_name                 = "shared-services.eu-west-2.configs.ch.gov.uk"
+  alb_idle_timeout                   = 180
+  enable_sns_topic                   = var.enable_sns_topic
+  create_app_target_group            = false
+  ssh_access_security_group_patterns = var.ssh_access_security_group_patterns
 
   additional_ingress_with_cidr_blocks = [
     {

--- a/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-live-eu-west-2/vars
@@ -18,6 +18,12 @@ instance_size = "t3.large"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Security Groups with SSH access
+ssh_access_security_group_patterns = [
+  "sgr-chips-control-asg-001-*",
+  "sgr-gfn-app-001-*"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-tux-proxy/variables.tf
+++ b/groups/chips-tux-proxy/variables.tf
@@ -119,6 +119,12 @@ variable "enable_instance_refresh" {
   description = "Enable or disable instance refresh when the ASG is updated"
 }
 
+variable "ssh_access_security_group_patterns" {
+  type        = list(string)
+  description = "List of source security group name patterns that will have SSH access"
+  default     = ["sgr-chips-control-asg-001-*"]
+}
+
 # ------------------------------------------------------------------------------
 # CHIPS ALB Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,28 +28,29 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.182"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.183"
 
-  application                      = var.application
-  application_type                 = "chips"
-  aws_region                       = var.aws_region
-  aws_account                      = var.aws_account
-  account                          = var.account
-  region                           = var.region
-  environment                      = var.environment
-  asg_count                        = var.asg_count
-  instance_size                    = var.instance_size
-  enable_instance_refresh          = var.enable_instance_refresh
-  nfs_mount_destination_parent_dir = var.nfs_mount_destination_parent_dir
-  nfs_mounts                       = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
-  cloudwatch_logs                  = var.cloudwatch_logs
-  config_bucket_name               = "shared-services.eu-west-2.configs.ch.gov.uk"
-  alb_idle_timeout                 = 180
-  enable_sns_topic                 = var.enable_sns_topic
-  create_nlb                       = true
-  maximum_5xx_threshold            = 5
-  maximum_4xx_threshold            = 5
-  test_access_enable               = var.test_access_enable
+  application                        = var.application
+  application_type                   = "chips"
+  aws_region                         = var.aws_region
+  aws_account                        = var.aws_account
+  account                            = var.account
+  region                             = var.region
+  environment                        = var.environment
+  asg_count                          = var.asg_count
+  instance_size                      = var.instance_size
+  enable_instance_refresh            = var.enable_instance_refresh
+  nfs_mount_destination_parent_dir   = var.nfs_mount_destination_parent_dir
+  nfs_mounts                         = jsondecode(data.vault_generic_secret.nfs_mounts.data["${var.application}-mounts"])
+  cloudwatch_logs                    = var.cloudwatch_logs
+  config_bucket_name                 = "shared-services.eu-west-2.configs.ch.gov.uk"
+  alb_idle_timeout                   = 180
+  enable_sns_topic                   = var.enable_sns_topic
+  create_nlb                         = true
+  maximum_5xx_threshold              = 5
+  maximum_4xx_threshold              = 5
+  test_access_enable                 = var.test_access_enable
+  ssh_access_security_group_patterns = var.ssh_access_security_group_patterns
 
   additional_ingress_with_cidr_blocks = [
     {

--- a/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-live-eu-west-2/vars
@@ -18,6 +18,12 @@ instance_size = "z1d.xlarge"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Security Groups with SSH access
+ssh_access_security_group_patterns = [
+  "sgr-chips-control-asg-001-*",
+  "sgr-gfn-app-001-*"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-users-rest/variables.tf
+++ b/groups/chips-users-rest/variables.tf
@@ -119,6 +119,12 @@ variable "enable_instance_refresh" {
   description = "Enable or disable instance refresh when the ASG is updated"
 }
 
+variable "ssh_access_security_group_patterns" {
+  type        = list(string)
+  description = "List of source security group name patterns that will have SSH access"
+  default     = ["sgr-chips-control-asg-001-*"]
+}
+
 # ------------------------------------------------------------------------------
 # CHIPS ALB Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Override the default list of source security groups for SSH access to allow ingress from the analytics/grafana server.
This is only required in Live.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1509