### PR TITLE
Add environment to the RDS SG name

### DIFF
--- a/groups/staffware-rds/rds.tf
+++ b/groups/staffware-rds/rds.tf
@@ -6,8 +6,8 @@ module "rds_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 3.0"
 
-  name        = "sgr-${var.identifier}-rds-001"
-  description = "Security group for the ${var.identifier} RDS database"
+  name        = "sgr-${var.identifier}-${var.environment}-rds-001"
+  description = "Security group for the ${var.identifier}-${var.environment} RDS database"
   vpc_id      = data.aws_vpc.vpc.id
 
   ingress_rules            = ["oracle-db-tcp"]


### PR DESCRIPTION
Renames the 3 RDS security groups for the Staffware/iProcess RDS instances, so that the environment name forms part of the security group name.  This is required in order to reference the correct security group from the iProcess app terraform.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1399