### PR TITLE
updating backup bucket to point to rep

### DIFF
--- a/groups/chips-reginit/locals.tf
+++ b/groups/chips-reginit/locals.tf
@@ -24,7 +24,7 @@ locals {
 
   resources_bucket_name       = local.shared_services_s3_data["resources_bucket_name"]
   session_manager_bucket_name = local.security_s3_data["session-manager-bucket-name"]
-  backup_bucket_name          = "${var.application}-backup-${var.aws_account}-${var.aws_region}"
+  backup_bucket_name          = "chips-rep-backup-heritage-live-eu-west-2"
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 


### PR DESCRIPTION
This is so we can restore the db from rep to reginit. reginit does not need backing up