### PR TITLE
Allow ingress to 1521 from Weblogic and iProcess apps

### DIFF
--- a/groups/staffware-rds/data.tf
+++ b/groups/staffware-rds/data.tf
@@ -19,6 +19,20 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
+data "aws_security_group" "chips_devtest_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-chips-devtest-asg-001-*"]
+  }
+}
+
+data "aws_security_group" "iprocess_app" {
+  filter {
+    name   = "group-name"
+    values = ["sgr-iprocess-app-${var.environment}-asg-001-*"]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/staffware-rds/rds.tf
+++ b/groups/staffware-rds/rds.tf
@@ -29,6 +29,26 @@ resource "aws_security_group_rule" "oem_rule" {
   security_group_id = module.rds_security_group.this_security_group_id
 }
 
+resource "aws_security_group_rule" "weblogic_app" {
+  description              = "Weblogic app access to DB"
+  from_port                = 1521
+  to_port                  = 1521
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = data.aws_security_group.chips_devtest_app.id
+  security_group_id        = module.rds_security_group.this_security_group_id
+}
+
+resource "aws_security_group_rule" "chips_iprocess_app" {
+  description              = "iProcess app access to DB"
+  from_port                = 1521
+  to_port                  = 1521
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = data.aws_security_group.iprocess_app.id
+  security_group_id        = module.rds_security_group.this_security_group_id
+}
+
 # ------------------------------------------------------------------------------
 # RDS Instance
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Allow the chips-devtest and iProcess app instances access to the staffware/iProcess RDS DBs