### PR TITLE
Add post bootstrap command to allow start of AppDynamics machine agent

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -72,9 +72,6 @@ module "chips-ef-batch" {
     }
   ]
 
-  additional_userdata_suffix = <<-EOT
-  su -l ec2-user weblogic-pre-bootstrap.sh
-  su -l ec2-user bootstrap
-  EOT
+  additional_userdata_suffix = join("\n",concat(var.bootstrap_commands, var.post_bootstrap_commands))
 
 }

--- a/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-ef-batch/profiles/heritage-staging-eu-west-2/vars
@@ -18,6 +18,11 @@ instance_size = "z1d.large"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Post bootstrap commands
+post_bootstrap_commands = [
+  "su -l ec2-user /home/ec2-user/machineagent/start-appd-machine-agent.sh"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-ef-batch/variables.tf
+++ b/groups/chips-ef-batch/variables.tf
@@ -187,3 +187,18 @@ variable "enable_sns_topic" {
   description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
   default     = false
 }
+
+variable "bootstrap_commands" {
+  type        = list(string)
+  default     = [
+    "su -l ec2-user weblogic-pre-bootstrap.sh",
+    "su -l ec2-user bootstrap"
+  ]
+  description = "List of bootstrap commands to run during the instance startup"
+}
+
+variable "post_bootstrap_commands" {
+  type        = list(string)
+  default     = []
+  description = "List of commands to run after the bootstrap commands on instance startup"
+}

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -66,8 +66,5 @@ module "chips-tux-proxy" {
     }
   ]
 
-  additional_userdata_suffix = <<-EOT
-  su -l ec2-user weblogic-pre-bootstrap.sh
-  su -l ec2-user bootstrap
-  EOT
+  additional_userdata_suffix = join("\n",concat(var.bootstrap_commands, var.post_bootstrap_commands))
 }

--- a/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-tux-proxy/profiles/heritage-staging-eu-west-2/vars
@@ -18,6 +18,11 @@ instance_size = "t3.large"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Post bootstrap commands
+post_bootstrap_commands = [
+  "su -l ec2-user /home/ec2-user/machineagent/start-appd-machine-agent.sh"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-tux-proxy/variables.tf
+++ b/groups/chips-tux-proxy/variables.tf
@@ -187,3 +187,18 @@ variable "enable_sns_topic" {
   description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
   default     = false
 }
+
+variable "bootstrap_commands" {
+  type        = list(string)
+  default     = [
+    "su -l ec2-user weblogic-pre-bootstrap.sh",
+    "su -l ec2-user bootstrap"
+  ]
+  description = "List of bootstrap commands to run during the instance startup"
+}
+
+variable "post_bootstrap_commands" {
+  type        = list(string)
+  default     = []
+  description = "List of commands to run after the bootstrap commands on instance startup"
+}

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.183"
+  source = "./chips-app"
 
   application                        = var.application
   application_type                   = "chips"
@@ -76,8 +76,5 @@ module "chips-users-rest" {
     }
   ]
 
-  additional_userdata_suffix = <<-EOT
-  su -l ec2-user weblogic-pre-bootstrap.sh
-  su -l ec2-user bootstrap
-  EOT
+  additional_userdata_suffix = join("\n",concat(var.bootstrap_commands, var.post_bootstrap_commands))
 }

--- a/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-development-eu-west-2/vars
@@ -16,6 +16,11 @@ asg_count = 1
 instance_size = "z1d.large"
 enable_instance_refresh = true
 
+# Post bootstrap commands
+post_bootstrap_commands = [
+  "su -l ec2-user /home/ec2-user/machineagent/start-appd-machine-agent.sh"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-users-rest/profiles/heritage-staging-eu-west-2/vars
@@ -18,6 +18,11 @@ instance_size = "z1d.large"
 # SNS Topic creation
 enable_sns_topic = true
 
+# Post bootstrap commands
+post_bootstrap_commands = [
+  "su -l ec2-user /home/ec2-user/machineagent/start-appd-machine-agent.sh"
+]
+
 # NFS Mounts
 nfs_mount_destination_parent_dir = "/mnt/nfs"
 

--- a/groups/chips-users-rest/variables.tf
+++ b/groups/chips-users-rest/variables.tf
@@ -193,3 +193,18 @@ variable "enable_sns_topic" {
   description = "A boolean value to indicate whether to deploy SNS topic configuration for CloudWatch actions"
   default     = false
 }
+
+variable "bootstrap_commands" {
+  type        = list(string)
+  default     = [
+    "su -l ec2-user weblogic-pre-bootstrap.sh",
+    "su -l ec2-user bootstrap"
+  ]
+  description = "List of bootstrap commands to run during the instance startup"
+}
+
+variable "post_bootstrap_commands" {
+  type        = list(string)
+  default     = []
+  description = "List of commands to run after the bootstrap commands on instance startup"
+}


### PR DESCRIPTION
Adds a command to the user data script, to call the AppDynamics machine agent start script on chips-users-rest0 on development, and chips-users-rest0/1, chips-ef-batch0/1 and chips-tux-proxy0/1 on staging.


Resolves:
https://companieshouse.atlassian.net/browse/CM-1542