### PR TITLE
Add ingress from CHS app subnets to port 1521 on Staffware DB

### DIFF
--- a/groups/staffware-db/data.tf
+++ b/groups/staffware-db/data.tf
@@ -94,6 +94,10 @@ data "vault_generic_secret" "ssm" {
   path = "aws-accounts/${var.aws_account}/ssm"
 }
 
+data "vault_generic_secret" "chs_subnets" {
+  path = "aws-accounts/network/${var.aws_account}/chs/application-subnets"
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/staffware-db/ec2.tf
+++ b/groups/staffware-db/ec2.tf
@@ -40,6 +40,13 @@ module "db_ec2_security_group" {
       protocol    = "tcp"
       description = "SSH ports"
       cidr_blocks = join(",", local.ssh_allowed_ranges)
+    },
+    {
+      from_port   = 1521
+      to_port     = 1521
+      protocol    = "tcp"
+      description = "Oracle DB port from CHS app subnets"
+      cidr_blocks = join(",", local.chs_subnet_data)
     }
   ]
   egress_rules = ["all-all"]

--- a/groups/staffware-db/locals.tf
+++ b/groups/staffware-db/locals.tf
@@ -14,6 +14,7 @@ locals {
   kms_keys_data           = data.vault_generic_secret.kms_keys.data
   security_kms_keys_data  = data.vault_generic_secret.security_kms_keys.data
   ssm_data                = data.vault_generic_secret.ssm.data
+  chs_subnet_data         = values(data.vault_generic_secret.chs_subnets.data)
 
   logs_kms_key_id        = local.kms_keys_data["logs"]
   ssm_logs_key_id        = local.kms_keys_data["ssm"]


### PR DESCRIPTION
Allow access form CHS application subnets to the Staffware Oracle DB server on port 1521.  This is to allow the CHS Transaction Search Tool to connect to the Staffware DB.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1545