### PR TITLE
adding OEM ports and ssh access

### DIFF
--- a/groups/chips-rep-db/ec2.tf
+++ b/groups/chips-rep-db/ec2.tf
@@ -43,6 +43,26 @@ module "db_ec2_security_group" {
     }
   ]
 
+  ingress_with_source_security_group_id = [for group in local.source_security_group_id :
+    {
+      from_port                = 3872
+      to_port                  = 3872
+      protocol                 = "tcp"
+      description              = "For OEM Adgent"
+      source_security_group_id = group
+    }
+  ]
+
+    ingress_with_source_security_group_id = [for group in local.source_security_group_id :
+    {
+      from_port                = 4903
+      to_port                  = 4903
+      protocol                 = "tcp"
+      description              = "For OEM Adgent"
+      source_security_group_id = group
+    }
+  ]
+
   egress_rules = ["all-all"]
 }
 

--- a/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-staging-eu-west-2/vars
@@ -108,7 +108,8 @@ chips_rep_db_sg = [
   "sgr-chips-read-only-asg-001-*",
   "sgr-chips-db-batch-asg-001-*",
   "sgr-windows-workloads-bus-obj-2-server-*",
-  "sgr-chips-oltp-logstb-db-ec2-001-*"
+  "sgr-chips-oltp-logstb-db-ec2-001-*",
+  "sgr-chips-oem-ec2-001-*"
 ]
 
 


### PR DESCRIPTION
This is to allow ssh access from the OEM server to rep and added the ports required for the agent.