### PR TITLE
Pass ami_name var through to chips-app module

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -37,6 +37,7 @@ module "chips-ef-batch" {
   account                            = var.account
   region                             = var.region
   environment                        = var.environment
+  ami_name                           = var.ami_name
   asg_count                          = var.asg_count
   instance_size                      = var.instance_size
   enable_instance_refresh            = var.enable_instance_refresh

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -37,6 +37,7 @@ module "chips-read-only" {
   account                            = var.account
   region                             = var.region
   environment                        = var.environment
+  ami_name                           = var.ami_name
   asg_count                          = var.asg_count
   instance_size                      = var.instance_size
   enable_instance_refresh            = var.enable_instance_refresh

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -37,6 +37,7 @@ module "chips-tux-proxy" {
   account                            = var.account
   region                             = var.region
   environment                        = var.environment
+  ami_name                           = var.ami_name
   asg_count                          = var.asg_count
   instance_size                      = var.instance_size
   enable_instance_refresh            = var.enable_instance_refresh

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -37,6 +37,7 @@ module "chips-users-rest" {
   account                            = var.account
   region                             = var.region
   environment                        = var.environment
+  ami_name                           = var.ami_name
   asg_count                          = var.asg_count
   instance_size                      = var.instance_size
   enable_instance_refresh            = var.enable_instance_refresh


### PR DESCRIPTION
Passes the existing ami_name var through to the underlying chips-app module so that the pipeline can set the version of the docker-ami image.

Partially resolves:
https://companieshouse.atlassian.net/browse/CM-1550