### PR TITLE
Allow access from dba-dev

### DIFF
--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -109,7 +109,8 @@ chips_db_sg = [
   "sgr-chips-uam-ec2-001-*",
   "sgr-bcd-rds-001-*",
   "sgr-ewf-rds-001-*",
-  "sgr-chips-oltp-logstb-db-ec2*"
+  "sgr-chips-oltp-logstb-db-ec2*",
+  "sgr-chips-dba-dev-db-ec2-001-*"
 ]
 
 # OEM Security Group


### PR DESCRIPTION
Update access for chips-db staging to permit connectivity from dba-dev security group