### PR TITLE
Allow test migration access

### DIFF
--- a/groups/chips-db/data.tf
+++ b/groups/chips-db/data.tf
@@ -149,5 +149,5 @@ data "aws_security_group" "oem" {
 }
 
 data "vault_generic_secret" "migration_cidrs" {
-  path = "applications/${aws_profile}/${application}/migration_cidrs"
+  path = "applications/${var.aws_profile}/${var.application}/migration_cidrs"
 }

--- a/groups/chips-db/data.tf
+++ b/groups/chips-db/data.tf
@@ -147,3 +147,7 @@ data "aws_security_group" "oem" {
     values = [var.chips_oltp_oem_sg]
   }
 }
+
+data "vault_generic_secret" "migration_cidrs" {
+  path = "applications/${aws_profile}/${application}/migration_cidrs"
+}

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -126,8 +126,8 @@ resource "aws_security_group_rule" "test_access" {
 }
 
 resource "aws_security_group_rule" "sp_migration" {
-  count = length(var.sp_migration_cidrs) > 0 ? {
-    for idx, cidr in var.sp_migration_cidrs : idx => cidr
+  count = length(local.sp_migration_cidrs) > 0 ? {
+    for idx, cidr in local.sp_migration_cidrs : idx => cidr
   } : {}
 
   type        = "ingress"

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -113,7 +113,7 @@ resource "aws_security_group_rule" "OEM_listener" {
 }
 
 resource "aws_security_group_rule" "test_access" {
-  count = length(var.test_access_cidrs) > 0 ? {
+  for_each = length(var.test_access_cidrs) > 0 ? {
     for idx, cidr in var.test_access_cidrs : idx => cidr
   } : {}
 
@@ -127,7 +127,7 @@ resource "aws_security_group_rule" "test_access" {
 }
 
 resource "aws_security_group_rule" "sp_migration" {
-  count = length(local.sp_migration_cidrs) > 0 ? {
+  for_each = length(local.sp_migration_cidrs) > 0 ? {
     for idx, cidr in local.sp_migration_cidrs : idx => cidr
   } : {}
 

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -112,6 +112,32 @@ resource "aws_security_group_rule" "OEM_listener" {
   security_group_id        = module.db_ec2_security_group.this_security_group_id
 }
 
+resource "aws_security_group_rule" "test_access" {
+  count = length(var.test_access_cidrs) > 0 ? {
+    for idx, cidr in var.test_access_cidrs : idx => cidr
+  } : {}
+
+  type        = "ingress"
+  description = "Test access"
+  from_port   = 1522
+  to_port     = 1522
+  protocol    = "tcp"
+  cidr_blocks = [each.value]
+}
+
+resource "aws_security_group_rule" "sp_migration" {
+  count = length(var.sp_migration_cidrs) > 0 ? {
+    for idx, cidr in var.sp_migration_cidrs : idx => cidr
+  } : {}
+
+  type        = "ingress"
+  description = "SP migration access"
+  from_port   = 1521
+  to_port     = 1522
+  protocol    = "tcp"
+  cidr_blocks = [each.value]
+}
+
 # ------------------------------------------------------------------------------
 # EC2
 # ------------------------------------------------------------------------------

--- a/groups/chips-db/ec2.tf
+++ b/groups/chips-db/ec2.tf
@@ -117,12 +117,13 @@ resource "aws_security_group_rule" "test_access" {
     for idx, cidr in var.test_access_cidrs : idx => cidr
   } : {}
 
-  type        = "ingress"
-  description = "Test access"
-  from_port   = 1522
-  to_port     = 1522
-  protocol    = "tcp"
-  cidr_blocks = [each.value]
+  type              = "ingress"
+  description       = "Test access"
+  from_port         = 1522
+  to_port           = 1522
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = module.db_ec2_security_group.this_security_group_id
 }
 
 resource "aws_security_group_rule" "sp_migration" {
@@ -130,12 +131,13 @@ resource "aws_security_group_rule" "sp_migration" {
     for idx, cidr in local.sp_migration_cidrs : idx => cidr
   } : {}
 
-  type        = "ingress"
-  description = "SP migration access"
-  from_port   = 1521
-  to_port     = 1522
-  protocol    = "tcp"
-  cidr_blocks = [each.value]
+  type              = "ingress"
+  description       = "SP migration access"
+  from_port         = 1521
+  to_port           = 1522
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = module.db_ec2_security_group.this_security_group_id
 }
 
 # ------------------------------------------------------------------------------

--- a/groups/chips-db/locals.tf
+++ b/groups/chips-db/locals.tf
@@ -112,5 +112,5 @@ locals {
 
   source_security_group_id = [for item in data.aws_security_group.chips_sg : item.id]
 
-  sp_migration_cidrs = data.vault_generic_secret.migration_cidrs.sp_migration_cidrs
+  sp_migration_cidrs = jsondecode(data.vault_generic_secret.migration_cidrs.data_json)["sp_migration_cidrs"]
 }

--- a/groups/chips-db/locals.tf
+++ b/groups/chips-db/locals.tf
@@ -111,4 +111,6 @@ locals {
   failover_approvers = distinct(compact(flatten([for roles in data.aws_iam_roles.failover_approvers : roles.arns])))
 
   source_security_group_id = [for item in data.aws_security_group.chips_sg : item.id]
+
+  sp_migration_cidrs = data.vault_generic_secret.migration_cidrs.sp_migration_cidrs
 }

--- a/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chips-db/profiles/heritage-staging-eu-west-2/vars
@@ -124,3 +124,8 @@ alarm_topic_name_ooh   = ""
 
 # RMAN disk
 create_rman_volumes = true
+
+# OLTP DB Test Access CIDR Range
+test_access_cidrs = [
+  "10.50.17.0/24"
+]

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -381,7 +381,7 @@ variable "chips_oltp_oem_sg" {
 }
 
 variable "test_access_cidrs" {
-  type        = string
+  type        = list(string)
   description = "A List of the CIDR range used for test access"
-  default     = ""
+  default     = []
 }

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -379,3 +379,9 @@ variable "chips_oltp_oem_sg" {
   description = "OEM Security Group"
   default     = ""
 }
+
+variable "test_access_cidrs" {
+  type        = string
+  description = "A List of the CIDR range used for test access"
+  default     = ""
+}


### PR DESCRIPTION
Enabling Test & migration Access via new SG's

One SG for [Staging](https://companieshouse.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D852a4f3c979e5190fb3a3a1f2153afa3%26sysparm_view%3D%26sysparm_domain%3Dnull%26sysparm_domain_scope%3Dnull%26sysparm_record_row%3D28%26sysparm_record_rows%3D81%26sysparm_record_list%3Dactive%253dtrue%255eassignment_group%253djavascript%253agetMyGroups()%255estate!%253d6%255eORDERBYsys_created_on) & one SG for [Live](https://companieshouse.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3Dbf20507a97ce115006b37e371153af01%26sysparm_view%3D%26sysparm_domain%3Dnull%26sysparm_domain_scope%3Dnull%26sysparm_record_row%3D27%26sysparm_record_rows%3D81%26sysparm_record_list%3Dactive%253dtrue%255eassignment_group%253djavascript%253agetMyGroups()%255estate!%253d6%255eORDERBYsys_created_on). A '/32' subnet was required for Live so new secrets have been added to vault appropriately.
