### PR TITLE
Avoid embedding sensitive data in the user data script

### DIFF
--- a/groups/staffware-app/data.tf
+++ b/groups/staffware-app/data.tf
@@ -128,12 +128,13 @@ data "template_file" "userdata" {
   template = file("${path.module}/templates/user_data.tpl")
 
   vars = {
-    APPLICATION               = var.component
-    HERITAGE_ENVIRONMENT      = title(var.environment)
-    R53_ZONEID                = data.aws_route53_zone.private_zone.zone_id
-    IPROCESS_APP_INPUTS       = jsonencode(local.iprocess_app_deployment_ansible_inputs)
-    IPROCESS_TNS_INPUTS       = jsonencode(local.iprocess_tnsnames_inputs)
-    IPROCESS_STAFF_DAT_INPUTS = jsonencode(local.iprocess_staff_dat_inputs)
+    APPLICATION                    = var.component
+    HERITAGE_ENVIRONMENT           = title(var.environment)
+    REGION                         = var.aws_region
+    R53_ZONEID                     = data.aws_route53_zone.private_zone.zone_id
+    DEPLOYMENT_ANSIBLE_INPUTS_PATH = "${local.parameter_store_path_prefix}/deployment_ansible_inputs"
+    TNSNAMES_INPUTS_PATH           = "${local.parameter_store_path_prefix}/tnsnames_inputs"
+    STAFF_DAT_INPUTS_PATH          = "${local.parameter_store_path_prefix}/staff_dat_inputs"
   }
 }
 

--- a/groups/staffware-app/iam.tf
+++ b/groups/staffware-app/iam.tf
@@ -20,7 +20,8 @@ module "iprocess_app_profile" {
   ]) : null
   kms_key_refs = [
     "alias/${var.account}/${var.region}/ebs",
-    local.ssm_kms_key_id
+    local.ssm_kms_key_id,
+    local.account_ssm_key_arn
   ]
   custom_statements = [
     {
@@ -59,6 +60,14 @@ module "iprocess_app_profile" {
       resources = ["*"]
       actions = [
         "ec2:Describe*"
+      ]
+    },
+    {
+      sid       = "AllowReadOfParameterStore",
+      effect    = "Allow",
+      resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${var.application}/${var.environment}/*"],
+      actions = [
+        "ssm:GetParameter*"
       ]
     }
   ]

--- a/groups/staffware-app/locals.tf
+++ b/groups/staffware-app/locals.tf
@@ -11,6 +11,7 @@ locals {
   security_kms_keys_data = data.vault_generic_secret.security_kms_keys.data
   logs_kms_key_id        = local.kms_keys_data["logs"]
   sns_kms_key_id         = local.kms_keys_data["sns"]
+  account_ssm_key_arn    = local.kms_keys_data["ssm"]
   ssm_kms_key_id         = local.security_kms_keys_data["session-manager-kms-key-arn"]
 
   security_s3_data            = data.vault_generic_secret.security_s3_buckets.data
@@ -51,6 +52,14 @@ locals {
 
   iprocess_staff_dat_inputs = {
     staff_dat = local.iprocess_app_config_data["staff_dat"]
+  }
+
+  parameter_store_path_prefix = "/${var.application}/${var.environment}"
+
+  parameter_store_secrets = {
+    deployment_ansible_inputs = jsonencode(local.iprocess_app_deployment_ansible_inputs)
+    tnsnames_inputs           = jsonencode(local.iprocess_tnsnames_inputs)
+    staff_dat_inputs          = jsonencode(local.iprocess_staff_dat_inputs)
   }
 
   default_tags = {

--- a/groups/staffware-app/parameter-store.tf
+++ b/groups/staffware-app/parameter-store.tf
@@ -1,0 +1,13 @@
+resource "aws_ssm_parameter" "parameters" {
+  for_each = local.parameter_store_secrets
+
+  name   = "${local.parameter_store_path_prefix}/${each.key}"
+  type   = "SecureString"
+  value  = each.value
+  key_id = local.account_ssm_key_arn
+
+  tags = {
+    Environment = var.environment
+    Application = var.application
+  }
+}

--- a/groups/staffware-app/templates/user_data.tpl
+++ b/groups/staffware-app/templates/user_data.tpl
@@ -6,22 +6,18 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 cp /usr/local/bin/nagios-host-add.sh /usr/local/bin/nagios-host-add.j2
 REPLACE=${APPLICATION}_${HERITAGE_ENVIRONMENT} /usr/local/bin/j2 /usr/local/bin/nagios-host-add.j2 > /usr/local/bin/nagios-host-add.sh
 
+GET_PARAM_COMMAND="aws ssm get-parameter --with-decryption --region ${REGION} --output text --query Parameter.Value --name"
+
 #Use provided inputs to create final tnsnames.ora file
-cat <<EOF >>tnsnames.json
-${IPROCESS_TNS_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${TNSNAMES_INPUTS_PATH}' > tnsnames.json
 /usr/local/bin/j2 -f json /home/swenvp1/tnsnames.j2 tnsnames.json > /app/oracle/product/19c/network/admin/tnsnames.ora
 
 #Use provided inputs to create final staff.dat file
-cat <<'EOF' >>staff_dat.json
-${IPROCESS_STAFF_DAT_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${STAFF_DAT_INPUTS_PATH}' > staff_dat.json
 /usr/local/bin/j2 -f json /home/swenvp1/staff_dat.j2 staff_dat.json > /app/iProcess/11_8/staff.dat
 
 #Run Ansible playbook for app deployment using provided inputs
-cat <<EOF >deployment.json
-${IPROCESS_APP_INPUTS}
-EOF
+$${GET_PARAM_COMMAND} '${DEPLOYMENT_ANSIBLE_INPUTS_PATH}' > deployment.json
 /usr/local/bin/ansible-playbook /root/deployment.yml -e "@deployment.json"
 
 #Run DNS Update script with inputs


### PR DESCRIPTION
The iprocess-app-001 (Tibco iProcess/Staffware) EC2 instances contain sensitive data within the user data on the ch-heritage-dev, heritage-staging and heritage-live accounts. 

This change is to avoid embedding the sensitive data in the user data script and instead use parameter store, and access the data from there when the script runs.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2675
