### PR TITLE
Add policy to allow AWS Inspector CIS scanning to CHIPS application tier instances

### DIFF
--- a/groups/chips-db-batch/iam.tf
+++ b/groups/chips-db-batch/iam.tf
@@ -101,3 +101,8 @@ module "instance_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.instance_profile.aws_iam_role.name
+}

--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.245"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.251"
 
   application                        = var.application
   application_type                   = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.245"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.251"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.245"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.251"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.245"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.251"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/staffware-app/iam.tf
+++ b/groups/staffware-app/iam.tf
@@ -72,3 +72,8 @@ module "iprocess_app_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.iprocess_app_profile.aws_iam_role.name
+}


### PR DESCRIPTION
Attach the managed policy that allows Inspector CIS scanning to the chips-db-batch and staffware-app groups and reference 0.1.251 of the chips-app module to bring the same change in for chips-users-rest, chips-ef-batch, chips-read-only & chips-tux-proxy groups.


Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2793
