### PR TITLE
Add managed CIS scanning policy to db instance roles

### DIFF
--- a/groups/chips-db/iam.tf
+++ b/groups/chips-db/iam.tf
@@ -245,3 +245,8 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
     }
   }
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.db_instance_profile.aws_iam_role.name
+}

--- a/groups/chips-db/iam.tf
+++ b/groups/chips-db/iam.tf
@@ -247,8 +247,8 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
-  count      = var.inspector_policy ? 1 : 0
-  
+  count      = var.enable_inspector_scanning_policy ? 1 : 0
+
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.db_instance_profile.aws_iam_role.name
 }

--- a/groups/chips-db/iam.tf
+++ b/groups/chips-db/iam.tf
@@ -247,6 +247,8 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  count      = var.inspector_policy ? 1 : 0
+  
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.db_instance_profile.aws_iam_role.name
 }

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -207,7 +207,7 @@ variable "create_rman_volumes" {
   default     = false
 }
 
-variable "inspector_policy" {
+variable "enable_inspector_scanning_policy" {
   type        = bool
   description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
   default     = false

--- a/groups/chips-db/variables.tf
+++ b/groups/chips-db/variables.tf
@@ -207,6 +207,12 @@ variable "create_rman_volumes" {
   default     = false
 }
 
+variable "inspector_policy" {
+  type        = bool
+  description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
+  default     = false
+}
+
 # ------------------------------------------------------------------------------
 # NFS Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-oem/iam.tf
+++ b/groups/chips-oem/iam.tf
@@ -83,7 +83,7 @@ module "oem_instance_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
-  count      = var.inspector_policy ? 1 : 0
+  count      = var.enable_inspector_scanning_policy ? 1 : 0
   
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.oem_instance_profile.aws_iam_role.name

--- a/groups/chips-oem/iam.tf
+++ b/groups/chips-oem/iam.tf
@@ -81,3 +81,8 @@ module "oem_instance_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.oem_instance_profile.aws_iam_role.name
+}

--- a/groups/chips-oem/iam.tf
+++ b/groups/chips-oem/iam.tf
@@ -83,6 +83,8 @@ module "oem_instance_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  count      = var.inspector_policy ? 1 : 0
+  
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.oem_instance_profile.aws_iam_role.name
 }

--- a/groups/chips-oem/variables.tf
+++ b/groups/chips-oem/variables.tf
@@ -135,7 +135,7 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
-variable "inspector_policy" {
+variable "enable_inspector_scanning_policy" {
   type        = bool
   description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
   default     = false

--- a/groups/chips-oem/variables.tf
+++ b/groups/chips-oem/variables.tf
@@ -135,6 +135,12 @@ variable "availability_zones" {
   description = "List of availability zone names (e.g. [eu-west-2a, eu-west-2b]) to deploy instances into, usually to meet constraints such as remote storage locality. Leaving null will deploy across all matching subnets/zones in the provided VPC"
 }
 
+variable "inspector_policy" {
+  type        = bool
+  description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
+  default     = false
+}
+
 # ------------------------------------------------------------------------------
 # NFS Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-reginit/iam.tf
+++ b/groups/chips-reginit/iam.tf
@@ -81,3 +81,8 @@ module "reginit_instance_profile" {
     }
   ]
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.reginit_instance_profile.aws_iam_role.name
+}

--- a/groups/chips-reginit/iam.tf
+++ b/groups/chips-reginit/iam.tf
@@ -83,7 +83,7 @@ module "reginit_instance_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
-  count      = var.inspector_policy ? 1 : 0
+  count      = var.enable_inspector_scanning_policy ? 1 : 0
   
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.reginit_instance_profile.aws_iam_role.name

--- a/groups/chips-reginit/iam.tf
+++ b/groups/chips-reginit/iam.tf
@@ -83,6 +83,8 @@ module "reginit_instance_profile" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  count      = var.inspector_policy ? 1 : 0
+  
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.reginit_instance_profile.aws_iam_role.name
 }

--- a/groups/chips-reginit/variables.tf
+++ b/groups/chips-reginit/variables.tf
@@ -214,7 +214,7 @@ variable "data_volume_type" {
   default     = "gp3"
 }
 
-variable "inspector_policy" {
+variable "enable_inspector_scanning_policy" {
   type        = bool
   description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
   default     = false

--- a/groups/chips-reginit/variables.tf
+++ b/groups/chips-reginit/variables.tf
@@ -214,6 +214,12 @@ variable "data_volume_type" {
   default     = "gp3"
 }
 
+variable "inspector_policy" {
+  type        = bool
+  description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
+  default     = false
+}
+
 # ------------------------------------------------------------------------------
 # NFS Variables
 # ------------------------------------------------------------------------------

--- a/groups/chips-rep-db/iam.tf
+++ b/groups/chips-rep-db/iam.tf
@@ -242,3 +242,8 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
     }
   }
 }
+
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.db_instance_profile.aws_iam_role.name
+}

--- a/groups/chips-rep-db/iam.tf
+++ b/groups/chips-rep-db/iam.tf
@@ -244,6 +244,8 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  count      = var.inspector_policy ? 1 : 0
+  
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.db_instance_profile.aws_iam_role.name
 }

--- a/groups/chips-rep-db/iam.tf
+++ b/groups/chips-rep-db/iam.tf
@@ -244,7 +244,7 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
-  count      = var.inspector_policy ? 1 : 0
+  count      = var.enable_inspector_scanning_policy ? 1 : 0
   
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.db_instance_profile.aws_iam_role.name

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -195,7 +195,7 @@ variable "u01_volume_type" {
   default     = "gp2"
 }
 
-variable "inspector_policy" {
+variable "enable_inspector_scanning_policy" {
   type        = bool
   description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
   default     = false

--- a/groups/chips-rep-db/variables.tf
+++ b/groups/chips-rep-db/variables.tf
@@ -195,6 +195,12 @@ variable "u01_volume_type" {
   default     = "gp2"
 }
 
+variable "inspector_policy" {
+  type        = bool
+  description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
+  default     = false
+}
+
 # ------------------------------------------------------------------------------
 # Ansible SSM variables
 # ------------------------------------------------------------------------------

--- a/groups/staffware-db/iam.tf
+++ b/groups/staffware-db/iam.tf
@@ -246,7 +246,7 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
-  count      = var.inspector_policy ? 1 : 0
+  count      = var.enable_inspector_scanning_policy ? 1 : 0
   
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.db_instance_profile.aws_iam_role.name

--- a/groups/staffware-db/iam.tf
+++ b/groups/staffware-db/iam.tf
@@ -246,6 +246,8 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  count      = var.inspector_policy ? 1 : 0
+  
   policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   role       = module.db_instance_profile.aws_iam_role.name
 }

--- a/groups/staffware-db/iam.tf
+++ b/groups/staffware-db/iam.tf
@@ -245,3 +245,7 @@ data "aws_iam_policy_document" "eventbridge_ssm_execution_policy_document" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "inspector_cis_scanning_policy_attach" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
+  role       = module.db_instance_profile.aws_iam_role.name
+}

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -165,6 +165,12 @@ variable "u01_volume_type" {
   default     = "gp2"
 }
 
+variable "inspector_policy" {
+  type        = bool
+  description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
+  default     = false
+}
+
 # ------------------------------------------------------------------------------
 # Ansible SSM variables
 # ------------------------------------------------------------------------------

--- a/groups/staffware-db/variables.tf
+++ b/groups/staffware-db/variables.tf
@@ -165,7 +165,7 @@ variable "u01_volume_type" {
   default     = "gp2"
 }
 
-variable "inspector_policy" {
+variable "enable_inspector_scanning_policy" {
   type        = bool
   description = "Defines whether inspector policy is attached to instance profile to enable scanning (true) or not (false)"
   default     = false


### PR DESCRIPTION
Add managed policy to allow CIS scanning by Inspector.

Note that just because this policy is present, it doesn't mean that we can actually run CIS scans without assessing the impact (to performance etc), so it is likely this will just be used on staging and not live for the main chips dbs.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2793
