### PR TITLE
Allow access to staffware/iprocess rds dev/training DBs by new E2E app envs

### DIFF
--- a/groups/staffware-rds/data.tf
+++ b/groups/staffware-rds/data.tf
@@ -19,13 +19,6 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
-data "aws_security_group" "iprocess_app" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-iprocess-app-${var.environment}-asg-001-*"]
-  }
-}
-
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true
@@ -48,7 +41,7 @@ data "aws_ec2_managed_prefix_list" "administration" {
 }
 
 data "aws_security_groups" "db_access_group_ids" {
-  for_each = toset(var.rds_additional_sg_patterns)
+  for_each = toset(var.rds_access_sg_patterns)
   filter {
     name   = "group-name"
     values = [each.key]
@@ -56,6 +49,6 @@ data "aws_security_groups" "db_access_group_ids" {
 }
 
 data "aws_security_group" "db_access_groups" {
-  for_each = toset(local.additional_source_sg_ids)
+  for_each = toset(local.rds_access_source_sg_ids)
   id       = each.key
 }

--- a/groups/staffware-rds/data.tf
+++ b/groups/staffware-rds/data.tf
@@ -19,13 +19,6 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
-data "aws_security_group" "chips_devtest_app" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-chips-devtest-asg-001-*"]
-  }
-}
-
 data "aws_security_group" "iprocess_app" {
   filter {
     name   = "group-name"
@@ -52,4 +45,17 @@ data "vault_generic_secret" "staffware_rds" {
 
 data "aws_ec2_managed_prefix_list" "administration" {
   name = "administration-cidr-ranges"
+}
+
+data "aws_security_groups" "db_access_group_ids" {
+  for_each = toset(var.rds_additional_sg_patterns)
+  filter {
+    name   = "group-name"
+    values = [each.key]
+  }
+}
+
+data "aws_security_group" "db_access_groups" {
+  for_each = toset(local.additional_source_sg_ids)
+  id       = each.key
 }

--- a/groups/staffware-rds/locals.tf
+++ b/groups/staffware-rds/locals.tf
@@ -6,8 +6,8 @@ locals {
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
-  additional_source_sg_ids = flatten([for sg in data.aws_security_groups.db_access_group_ids : sg.ids])
-  additional_source_groups = {for group in data.aws_security_group.db_access_groups : group.tags.Name => group.id}
+  rds_access_source_sg_ids = flatten([for sg in data.aws_security_groups.db_access_group_ids : sg.ids])
+  rds_access_source_groups = {for group in data.aws_security_group.db_access_groups : group.tags.Name => group.id}
 
   default_tags = {
     Terraform = "true"

--- a/groups/staffware-rds/locals.tf
+++ b/groups/staffware-rds/locals.tf
@@ -6,6 +6,9 @@ locals {
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
+  additional_source_sg_ids = flatten([for sg in data.aws_security_groups.db_access_group_ids : sg.ids])
+  additional_source_groups = {for group in data.aws_security_group.db_access_groups : group.tags.Name => group.id}
+
   default_tags = {
     Terraform = "true"
     Region    = var.aws_region

--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/development/vars
@@ -29,6 +29,11 @@ rds_application_access_cidrs = [
   "10.94.6.242/32"
 ]
 
+rds_access_sg_patterns = [
+  "sgr-chips-*-asg-001-*",
+  "sgr-iprocess-app-development-asg-001-*"
+]
+
 # RDS logging
 rds_log_exports = [
   "alert",

--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/training1/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/training1/vars
@@ -25,6 +25,11 @@ engine_version             = "19"
 license_model              = "license-included"
 auto_minor_version_upgrade = false
 
+rds_access_sg_patterns = [
+  "sgr-chips-devtest-asg-001-*",
+  "sgr-iprocess-app-training1-asg-001-*"
+]
+
 # RDS logging
 rds_log_exports = [
   "alert",

--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/training2/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/training2/vars
@@ -25,6 +25,11 @@ engine_version             = "19"
 license_model              = "license-included"
 auto_minor_version_upgrade = false
 
+rds_access_sg_patterns = [
+  "sgr-chips-devtest-asg-001-*",
+  "sgr-iprocess-app-training2-asg-001-*"
+]
+
 # RDS logging
 rds_log_exports = [
   "alert",

--- a/groups/staffware-rds/rds.tf
+++ b/groups/staffware-rds/rds.tf
@@ -75,6 +75,7 @@ module "staffware_rds" {
   engine                     = "oracle-se2"
   major_engine_version       = var.major_engine_version
   engine_version             = var.engine_version
+  ca_cert_identifier         = var.ca_cert_identifier
   auto_minor_version_upgrade = var.auto_minor_version_upgrade
   license_model              = var.license_model
   instance_class             = var.instance_class

--- a/groups/staffware-rds/rds.tf
+++ b/groups/staffware-rds/rds.tf
@@ -29,16 +29,6 @@ resource "aws_security_group_rule" "oem_rule" {
   security_group_id = module.rds_security_group.this_security_group_id
 }
 
-resource "aws_security_group_rule" "weblogic_app" {
-  description              = "Weblogic app access to DB"
-  from_port                = 1521
-  to_port                  = 1521
-  protocol                 = "tcp"
-  type                     = "ingress"
-  source_security_group_id = data.aws_security_group.chips_devtest_app.id
-  security_group_id        = module.rds_security_group.this_security_group_id
-}
-
 resource "aws_security_group_rule" "chips_iprocess_app" {
   description              = "iProcess app access to DB"
   from_port                = 1521
@@ -59,6 +49,18 @@ resource "aws_security_group_rule" "application_access" {
   type              = "ingress"
   cidr_blocks       = var.rds_application_access_cidrs
   security_group_id = module.rds_security_group.this_security_group_id
+}
+
+resource "aws_security_group_rule" "additional_source_sg_access" {
+  for_each = tomap(local.additional_source_groups)
+
+  description              = "Access from ${each.key}"
+  from_port                = 1521
+  to_port                  = 1521
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = each.value
+  security_group_id        = module.rds_security_group.this_security_group_id
 }
 
 # ------------------------------------------------------------------------------

--- a/groups/staffware-rds/rds.tf
+++ b/groups/staffware-rds/rds.tf
@@ -29,16 +29,6 @@ resource "aws_security_group_rule" "oem_rule" {
   security_group_id = module.rds_security_group.this_security_group_id
 }
 
-resource "aws_security_group_rule" "chips_iprocess_app" {
-  description              = "iProcess app access to DB"
-  from_port                = 1521
-  to_port                  = 1521
-  protocol                 = "tcp"
-  type                     = "ingress"
-  source_security_group_id = data.aws_security_group.iprocess_app.id
-  security_group_id        = module.rds_security_group.this_security_group_id
-}
-
 resource "aws_security_group_rule" "application_access" {
   count = length(var.rds_application_access_cidrs) > 0 ? 1 : 0
 
@@ -51,8 +41,8 @@ resource "aws_security_group_rule" "application_access" {
   security_group_id = module.rds_security_group.this_security_group_id
 }
 
-resource "aws_security_group_rule" "additional_source_sg_access" {
-  for_each = tomap(local.additional_source_groups)
+resource "aws_security_group_rule" "source_sg_access" {
+  for_each = tomap(local.rds_access_source_groups)
 
   description              = "Access from ${each.key}"
   from_port                = 1521

--- a/groups/staffware-rds/variables.tf
+++ b/groups/staffware-rds/variables.tf
@@ -86,10 +86,10 @@ variable "rds_onpremise_access" {
   default     = []
 }
 
-variable "rds_additional_sg_patterns" {
+variable "rds_access_sg_patterns" {
   type        = list(string)
   description = "List of source security group name patterns that will have access to port 1521"
-  default     = ["sgr-chips-*-asg-001-*"]
+  default     = []
 }
 
 variable "performance_insights_enabled" {

--- a/groups/staffware-rds/variables.tf
+++ b/groups/staffware-rds/variables.tf
@@ -86,6 +86,12 @@ variable "rds_onpremise_access" {
   default     = []
 }
 
+variable "rds_additional_sg_patterns" {
+  type        = list(string)
+  description = "List of source security group name patterns that will have access to port 1521"
+  default     = ["sgr-chips-*-asg-001-*"]
+}
+
 variable "performance_insights_enabled" {
   type        = bool
   description = "Whether performance insights are required (true) or not (false). Typically enabled for Live resources."

--- a/groups/staffware-rds/variables.tf
+++ b/groups/staffware-rds/variables.tf
@@ -156,6 +156,12 @@ variable "auto_minor_version_upgrade" {
   default     = true
 }
 
+variable "ca_cert_identifier" {
+  type        = string
+  description = "Specifies the identifier of the CA certificate for the DB instance"
+  default     = "rds-ca-rsa2048-g1"
+}
+
 # ------------------------------------------------------------------------------
 # RDS CloudWatch Alarm Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Allows access based on source security group name patterns to staffware/iprocess RDS instances (development/training1/training2) for E2E/training weblogic and iprocess apps.

Also adds ca_cert_identifier var, with default of "rds-ca-rsa2048-g1" to match current infrastructure.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-53