### PR TITLE
Set sqlnetora.sqlnet.expire_time=10

### DIFF
--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/development/vars
@@ -105,6 +105,10 @@ parameter_group_settings = [
       value = "10"
     },
     {
+      name  = "sqlnetora.sqlnet.expire_time"
+      value = "10"
+    },
+    {
       name         = "timed_statistics"
       value        = "TRUE"
       apply_method = "pending-reboot"

--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/training1/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/training1/vars
@@ -101,6 +101,10 @@ parameter_group_settings = [
       value = "10"
     },
     {
+      name  = "sqlnetora.sqlnet.expire_time"
+      value = "10"
+    },
+    {
       name         = "timed_statistics"
       value        = "TRUE"
       apply_method = "pending-reboot"

--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/training2/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/training2/vars
@@ -101,6 +101,10 @@ parameter_group_settings = [
       value = "10"
     },
     {
+      name  = "sqlnetora.sqlnet.expire_time"
+      value = "10"
+    },
+    {
       name         = "timed_statistics"
       value        = "TRUE"
       apply_method = "pending-reboot"


### PR DESCRIPTION
Set `sqlnetora.sqlnet.expire_time=10` on the development, training1 & training2 Staffware RDS DB environments.  This matches a manual change previously applied to the development db, and also applies it to the training1 & 2 DBs for consistency.

Resolves:
https://companieshouse.atlassian.net/browse/CHP-233