### PR TITLE
Enable ELB deletion protection

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.292"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
 
   application                        = var.application
   application_type                   = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.292"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.292"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -29,7 +29,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.292"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
 
   application                        = var.application
   application_type                   = "chips"


### PR DESCRIPTION
In support of recent ITHC security audit, enabling ELB deletion protection in:

* chips-ef-batch
* chips-read-only
* chips-tux-proxy
* chips-users-rest