### PR TITLE
chips-users-rest custom ALB SG CIDR

### DIFF
--- a/groups/chips-ef-batch/main.tf
+++ b/groups/chips-ef-batch/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-ef-batch" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.317"
 
   application                        = var.application
   application_type                   = var.application_type

--- a/groups/chips-read-only/main.tf
+++ b/groups/chips-read-only/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-read-only" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.317"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/chips-tux-proxy/main.tf
+++ b/groups/chips-tux-proxy/main.tf
@@ -28,7 +28,7 @@ provider "vault" {
 }
 
 module "chips-tux-proxy" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.317"
 
   application                        = var.application
   application_type                   = "chips"

--- a/groups/chips-users-rest/data.tf
+++ b/groups/chips-users-rest/data.tf
@@ -1,3 +1,7 @@
 data "vault_generic_secret" "nfs_mounts" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application_type}/app/nfs_mounts"
 }
+
+data "vault_generic_secret" "client_cidrs" {
+  path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/client_cidrs"
+}

--- a/groups/chips-users-rest/locals.tf
+++ b/groups/chips-users-rest/locals.tf
@@ -1,0 +1,5 @@
+locals {
+
+    client_cidrs = values(data.vault_generic_secret.client_cidrs.data)
+
+}

--- a/groups/chips-users-rest/main.tf
+++ b/groups/chips-users-rest/main.tf
@@ -29,7 +29,7 @@ provider "vault" {
 }
 
 module "chips-users-rest" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.307"
+  source = "git@github.com:companieshouse/terraform-modules//aws/chips-app?ref=1.0.317"
 
   application                        = var.application
   application_type                   = "chips"
@@ -53,6 +53,7 @@ module "chips-users-rest" {
   maximum_4xx_threshold              = 5
   test_access_enable                 = var.test_access_enable
   ssh_access_security_group_patterns = var.ssh_access_security_group_patterns
+  additional_alb_ingress_cidr_blocks = local.client_cidrs
 
   additional_ingress_with_cidr_blocks = [
     {


### PR DESCRIPTION
A request to update the Serco VPN IP range in the chips-users-rest ALB SG, has highlighted that previously there was no support for specifying custom CIDRs for application specific ALB SGs (Serco should not have access to any other CHIPS app).

* updating chips-users-rest to pull an application specific client_cidrs value from Vault and passing to the chips-app TF module
* bumped module version for all four CHIPS apps, which will trigger the removal of the errant CIDR in the ALB SGs for all but chips-users-rest