### PR TITLE
Allow Staffware dev DB ingress from CHIPS E2E clone instances

### DIFF
--- a/groups/staffware-rds/profiles/heritage-development-eu-west-2/development/vars
+++ b/groups/staffware-rds/profiles/heritage-development-eu-west-2/development/vars
@@ -30,6 +30,7 @@ rds_application_access_cidrs = [
 ]
 
 rds_access_sg_patterns = [
+  "development-chips-e2e-*",
   "sgr-chips-*-asg-001-*",
   "sgr-iprocess-app-development-asg-001-*"
 ]


### PR DESCRIPTION
Updates the SG patterns to allow access to dev Staffware RDS from the CHIPS E2E clone instances.