### PR TITLE
Permit Access from DevTest

### DIFF
--- a/groups/chips-rds/data.tf
+++ b/groups/chips-rds/data.tf
@@ -39,3 +39,18 @@ data "vault_generic_secret" "chips_rds" {
 data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
+
+data "aws_ec2_managed_prefix_list" "admin" {
+  name = "administration-cidr-ranges"
+}
+
+data "aws_ec2_managed_prefix_list" "concourse" {
+  name = "shared-services-management-cidrs"
+}
+
+data "aws_security_groups" "oracle_ingress" {
+  filter {
+    name   = "group-name"
+    values = var.oracle_ingress_sg_patterns
+  }
+}

--- a/groups/chips-rds/locals.tf
+++ b/groups/chips-rds/locals.tf
@@ -2,10 +2,18 @@
 # Locals
 # ------------------------------------------------------------------------
 locals {
-  admin_cidrs    = values(data.vault_generic_secret.internal_cidrs.data)
   chips_rds_data = data.vault_generic_secret.chips_rds.data
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
+
+  oem_ingress_prefix_list_ids = [
+    data.aws_ec2_managed_prefix_list.admin.id
+  ]
+
+  oracle_ingress_prefix_list_ids = [
+    data.aws_ec2_managed_prefix_list.admin.id,
+    data.aws_ec2_managed_prefix_list.concourse.id
+  ]
 
   default_tags = {
     Terraform = "true"

--- a/groups/chips-rds/main.tf
+++ b/groups/chips-rds/main.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 0.3, < 4.0"
+      version = ">= 0.3, < 6.0"
     }
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 2.0.0"
+      version = ">= 4.0, < 5.0"
     }
   }
   backend "s3" {}

--- a/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chips-rds/profiles/heritage-development-eu-west-2/vars
@@ -110,6 +110,10 @@ parameter_group_settings = [
     },
 ]
 
+oracle_ingress_sg_patterns = [
+  "sgr-chips-devtest-asg*"
+]
+
 ## CloudWatch Alarms
 alarm_actions_enabled  = false
 alarm_topic_name       = ""

--- a/groups/chips-rds/variables.tf
+++ b/groups/chips-rds/variables.tf
@@ -167,3 +167,9 @@ variable "alarm_topic_name_ooh" {
   type        = string
   description = "The name of the SNS topic to use for OOH alarm notifications"
 }
+
+variable "oracle_ingress_sg_patterns" {
+  default     = []
+  description = "A list of security group name patterns that will bne permitted to connect to the Oracle service"
+  type        = list(string)
+}


### PR DESCRIPTION
Refactors security group rules to use discreet resources instead of module-controlled inline rules
Replace use of deprecated `admin_cidrs` Vault entry with prefix list
Add ability to specify a list of SG name patterns for SG-based ingress access
Defined `ca_cert_identifier` property to prevent unwanted config rollback

Resolves: INC0510105