### PR TITLE
Update chips-rep-db EC2 instance type

### DIFF
--- a/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chips-rep-db/profiles/heritage-live-eu-west-2/vars
@@ -13,7 +13,7 @@ oracle_unqname = "REPLIVE"
 oracle_sid = "REPLIVE"
 
 db_instance_count = 2
-db_instance_size = "r5.16xlarge"
+db_instance_size = "r6i.12xlarge"
 
 availability_zones = ["eu-west-2a","eu-west-2b"]
 


### PR DESCRIPTION
This change ensures that the EC2 instance type for `chips-rep-db` instances matches our current AWS infrastructure.